### PR TITLE
Fix workflow attribution error

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -51,6 +51,6 @@ jobs:
       
       - name: Publish PyPI
         env:
-          UV_PUBLISH_TOKEN: ${{ pypi.UV_PUBLISH_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
         run: uv publish
       


### PR DESCRIPTION
Now, release package can auto publish to PyPI