### PR TITLE
Add new tool to get_build_logs from Jenkins

### DIFF
--- a/src/mcp_jenkins/jenkins/_build.py
+++ b/src/mcp_jenkins/jenkins/_build.py
@@ -29,3 +29,16 @@ class JenkinsBuild:
                     parameters = {foo: foo} if not parameters else parameters
                     break
         return self._jenkins.build_job(fullname, parameters)
+
+    def get_build_logs(self, fullname: str, number: int) -> str:
+        """
+        Retrieve logs from a specific build.
+
+        Args:
+            fullname: The fullname of the job
+            number: The build number
+
+        Returns:
+            str: The logs of the build
+        """
+        return self._jenkins.get_build_console_output(fullname, number)

--- a/src/mcp_jenkins/server/build.py
+++ b/src/mcp_jenkins/server/build.py
@@ -15,7 +15,7 @@ async def get_running_builds(ctx: Context) -> list[dict]:
 
 
 @mcp.tool()
-async def get_build_info(ctx: Context, fullname: str, build_number: str) -> dict:
+async def get_build_info(ctx: Context, fullname: str, build_number: int | None = None) -> dict:
     """
     Get specific build info from Jenkins
 
@@ -26,7 +26,8 @@ async def get_build_info(ctx: Context, fullname: str, build_number: str) -> dict
     Returns:
         Build: The build info
     """
-    build_number = int(build_number)
+    if build_number is None:
+        build_number = client(ctx).job.get_job_info(fullname).lastBuild.number
     return client(ctx).build.get_build_info(fullname, build_number).model_dump(exclude_none=True)
 
 

--- a/src/mcp_jenkins/server/build.py
+++ b/src/mcp_jenkins/server/build.py
@@ -15,7 +15,7 @@ async def get_running_builds(ctx: Context) -> list[dict]:
 
 
 @mcp.tool()
-async def get_build_info(ctx: Context, fullname: str, build_number: int | None = None) -> dict:
+async def get_build_info(ctx: Context, fullname: str, build_number: str) -> dict:
     """
     Get specific build info from Jenkins
 
@@ -26,8 +26,7 @@ async def get_build_info(ctx: Context, fullname: str, build_number: int | None =
     Returns:
         Build: The build info
     """
-    if build_number is None:
-        build_number = client(ctx).job.get_job_info(fullname).lastBuild.number
+    build_number = int(build_number)
     return client(ctx).build.get_build_info(fullname, build_number).model_dump(exclude_none=True)
 
 
@@ -44,3 +43,19 @@ async def build_job(ctx: Context, fullname: str, parameters: dict = None) -> int
         The build number of the job
     """
     return client(ctx).build.build_job(fullname, parameters)
+
+
+@mcp.tool()
+async def get_build_logs(ctx: Context, fullname: str, build_number: str) -> str:
+    """
+    Get logs from a specific build in Jenkins
+
+    Args:
+        fullname: The fullname of the job
+        build_number: The number of the build
+
+    Returns:
+        str: The logs of the build
+    """
+    build_number = int(build_number)
+    return client(ctx).build.get_build_logs(fullname, build_number)


### PR DESCRIPTION
## Description

Added new functionality to interact with Jenkins build logs. Added `get_build_logs()` function with comprehensive unit tests covering:
   * Basic functionality with normal log output
   * Empty log handling
   * Unicode character support in logs
   * Error handling for non-existent builds


## Verification steps

1. Run `uv sync --all-extras --dev` to install dependencies
2. Run `uv run pytest tests/test_jenkins/test_build.py` to verify all tests pass
3. Check that test coverage for `mcp_jenkins/jenkins/_build.py` is 100%