### PR TITLE
Resolves #13. Add `--tool-alias` to support multiple Jenkins server

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ if __name__ == "__main__":
 | get_build_info     | Get build info               |
 | get_job_info       | Get job info                 |
 | build_job          | Build a job with param       |
+| get_build_logs     | Get build logs               |
 
 
 ## Development & Debugging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-jenkins"
-version = "0.2.1"
+version = "0.3.0"
 description = "The Model Context Protocol (MCP) is an open-source implementation that bridges Jenkins with AI language models following Anthropic's MCP specification. This project enables secure, contextual AI interactions with Jenkins tools while maintaining data privacy and security."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_jenkins/__init__.py
+++ b/src/mcp_jenkins/__init__.py
@@ -2,8 +2,6 @@ import os
 
 import click
 
-from mcp_jenkins.server import mcp
-
 
 @click.command()
 @click.option('--jenkins-url', required=True)
@@ -12,6 +10,13 @@ from mcp_jenkins.server import mcp
 @click.option('--jenkins-timeout', default=5)
 @click.option('--transport', type=click.Choice(['stdio', 'sse']), default='stdio')
 @click.option('--port', default=9887, help='Port to listen on for SSE transport')
+@click.option(
+    '--tool-alias',
+    default='[fn]',
+    help='The alias name for the server tool, use [fn] to replace with the origin tool name. '
+    'For example: If set to [fn]_on_commit_server, '
+    'the `get_running_builds` tool will be `get_running_builds_on_commit_server`.',
+)
 def main(
     jenkins_url: str,
     jenkins_username: str,
@@ -19,17 +24,24 @@ def main(
     jenkins_timeout: int,
     transport: str,
     port: int,
+    tool_alias: str,
 ) -> None:
     """
     Jenkins' functionality for MCP
     """
+    if '[fn]' not in tool_alias:
+        raise ValueError('Tool alias must contain [fn] placeholder')
+
     if all([jenkins_url, jenkins_username, jenkins_password, jenkins_timeout]):
         os.environ['jenkins_url'] = jenkins_url
         os.environ['jenkins_username'] = jenkins_username
         os.environ['jenkins_password'] = jenkins_password
         os.environ['jenkins_timeout'] = str(jenkins_timeout)
+        os.environ['tool_alias'] = tool_alias
     else:
         raise ValueError('Please provide valid jenkins_url, jenkins_username, and jenkins_password')
+
+    from mcp_jenkins.server import mcp
 
     if transport == 'sse':
         mcp.settings.port = port

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ cli = [
 
 [[package]]
 name = "mcp-jenkins"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Now, user can set `--tool-alias` to set alias name for MCP server tool.

For example:
```
# Start server cmd
[start command]  --tool-alias "[fn]_on_commit_server"
[start command]  --tool-alias "[fn]_via_user_admin"
```

In Cursor or Claude, user can ask agent to operate specific server like: `get running builds on commit server`, `get all jobs via user admin`