### PR TITLE
更新mcp官方库依赖到1.8.0以上用于支持streamable http协议

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "The Model Context Protocol (MCP) is an open-source implementation
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.6.0",
+    "mcp>=1.8.0",
     "pydantic>=2.11.1",
     "python-jenkins>=1.8.2",
     "beautifulsoup4>=4.12.2",
@@ -20,7 +20,7 @@ mcp-jenkins = "mcp_jenkins:main"
 
 [dependency-groups]
 dev = [
-    "mcp[cli]>=1.6.0",
+    "mcp[cli]>=1.8.0",
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-cov>=6.1.0",

--- a/src/mcp_jenkins/__init__.py
+++ b/src/mcp_jenkins/__init__.py
@@ -9,7 +9,7 @@ import click
 @click.option('--jenkins-password', required=True)
 @click.option('--jenkins-timeout', default=5)
 @click.option('--read-only', default=False, is_flag=True, help='Whether to run in read-only mode, default is False')
-@click.option('--transport', type=click.Choice(['stdio', 'sse']), default='stdio')
+@click.option('--transport', type=click.Choice(['stdio', 'sse', 'streamable-http']), default='stdio')
 @click.option('--port', default=9887, help='Port to listen on for SSE transport')
 @click.option(
     '--tool-alias',
@@ -46,7 +46,7 @@ def main(
 
     from mcp_jenkins.server import mcp
 
-    if transport == 'sse':
+    if transport in ['sse', 'streamable-http']:
         mcp.settings.port = port
     mcp.run(transport=transport)
 

--- a/tests/test_server/test_init.py
+++ b/tests/test_server/test_init.py
@@ -1,0 +1,63 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+# 设置必要的环境变量以避免导入错误
+os.environ['tool_alias'] = '[fn]'
+
+from mcp_jenkins import main
+
+
+def test_transport_streamable_http_valid():
+    """测试transport参数接受'streamable-http'值"""
+    with patch('mcp_jenkins.jenkins.JenkinsClient'), patch('mcp_jenkins.server.mcp') as mock_mcp:
+        mock_mcp.run = MagicMock()
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                '--jenkins-url',
+                'http://localhost',
+                '--jenkins-username',
+                'user',
+                '--jenkins-password',
+                'pass',
+                '--tool-alias',
+                '[fn]',
+                '--transport',
+                'streamable-http',
+            ],
+        )
+        assert result.exit_code == 0
+        mock_mcp.run.assert_called_once_with(transport='streamable-http')
+
+
+def test_transport_streamable_http_sets_port():
+    """测试transport为'streamable-http'时正确设置端口"""
+    with patch('mcp_jenkins.jenkins.JenkinsClient'), patch('mcp_jenkins.server.mcp') as mock_mcp:
+        mock_settings = MagicMock()
+        mock_mcp.settings = mock_settings
+        mock_mcp.run = MagicMock()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                '--jenkins-url',
+                'http://localhost',
+                '--jenkins-username',
+                'user',
+                '--jenkins-password',
+                'pass',
+                '--tool-alias',
+                '[fn]',
+                '--transport',
+                'streamable-http',
+                '--port',
+                '9888',
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_settings.port == 9888
+        mock_mcp.run.assert_called_once_with(transport='streamable-http')


### PR DESCRIPTION
更新mcp官方库依赖到1.8.0以上用于支持streamable http协议

修复git pre-commit脚本问题和gitignore uv.lock文件不生效问题的代码在现前的PR上，如果不希望合入之前的PR我可以把那两个修改提到这个PR上