### PR TITLE
feat: add Docker GHCR publishing

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,71 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Create 'master' tag on push to master branch
+            type=ref,event=branch,branch=master
+            # Create 'X.Y.Z', 'X.Y', 'X' tags on tag push (e.g., v1.2.3 -> 1.2.3, 1.2, 1)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # Only create 'latest' tag if it's a tag push AND it's a non-prerelease version tag (no '-')
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+          labels: |
+            org.opencontainers.image.title=MCP Jenkins
+            org.opencontainers.image.description=Model Context Protocol server for Jenkins integration
+            org.opencontainers.image.vendor=mcp-jenkins
+            org.opencontainers.image.version=${{ github.ref_name }}
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ pip install mcp-jenkins
 npx -y @smithery/cli@latest install @lanbaoshen/mcp-jenkins --client claude
 ```
 
+#### Docker Installation
+
+Pull the latest image from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/lanbaoshen/mcp-jenkins:latest
+```
+
+
 ### Configuration and Usage
 
 #### Cursor


### PR DESCRIPTION
 **Description**

This PR implements automated Docker image publishing to GitHub Container Registry (GHCR), making it easier for users to pull and run mcp-jenkins without building from source.


 **Added**
  -  GitHub Actions workflow (`.github/workflows/docker-publish.yaml`)
  - Multi-platform builds (linux/amd64, linux/arm64)
  - Automated publishing to GHCR
  