### PR TITLE
Add AgentCore Runtime compatibility with --host and --stateless-http options

### DIFF
--- a/src/mcp_jenkins/__init__.py
+++ b/src/mcp_jenkins/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 import click
+from mcp.server.transport_security import TransportSecuritySettings
 
 
 @click.command()
@@ -54,6 +55,11 @@ def main(
         mcp.settings.port = port
         mcp.settings.host = host
         mcp.settings.stateless_http = stateless_http
+        # AgentCore Runtime compatibility: Disable Host header validation when stateless_http is enabled
+        if stateless_http:
+            mcp.settings.transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=False
+            )
     mcp.run(transport=transport)
 
 


### PR DESCRIPTION
## Summary

This PR adds support for AWS Bedrock AgentCore Runtime by introducing two new CLI options and disabling DNS rebinding protection when running in stateless HTTP mode.

## Changes

1. **New CLI options**:

   - `--host`: Allows specifying the host to bind to for SSE/streamable-http transport (default: `127.0.0.1`)
   - `--stateless-http`: Enables stateless HTTP mode required by AgentCore Runtime for session isolation (default: `False`)

2. **DNS rebinding protection handling**:
   - When `--stateless-http` is enabled, DNS rebinding protection is automatically disabled
   - This allows the server to accept requests from AgentCore Runtime's internal hostnames (e.g., `cell01.ap-northeast-1.prod.arp.kepler-analytics.aws.dev`)

## Background

AWS Bedrock AgentCore Runtime requires MCP servers to:

1. Bind to `0.0.0.0` to accept requests from the internal network
2. Run in stateless HTTP mode for proper session isolation
3. Accept requests with internal AWS hostnames in the Host header

The default FastMCP behavior enables DNS rebinding protection when initialized with `host="127.0.0.1"`, which rejects requests from AgentCore Runtime's internal
hostnames with a 421 error.

## Example Usage

```bash
mcp-jenkins \
  --jenkins-url=https://jenkins.example.com \
  --jenkins-username=user \
  --jenkins-password=pass \
  --transport=streamable-http \
  --port=8000 \
  --host=0.0.0.0 \
  --stateless-http

Testing

Tested with AWS Bedrock AgentCore Runtime in production environment. The server successfully:
- Accepts requests from AgentCore Runtime
- Lists and executes tools without Host header validation errors
- Maintains session isolation with stateless HTTP mode

Related Issues

Fixes compatibility with AWS Bedrock AgentCore Runtime deployment.
```
