### PR TITLE
Update item/node config

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ uvx mcp-jenkins \
 |----------------------------|-----------------------------------------------------|
 | `get_item`                 | Get a specific item by name.                        |
 | `get_item_config`          | Get the configuration of a specific item.           |
+| `update_item_config`       | Update the configuration of a specific item.        |
 | `get_all_items`            | Get all items in Jenkins.                           |
 | `query_items`              | Query items based on pattern.                       |
 | `build_item`               | Build a item.                                       |
 | `get_all_nodes`            | Get all nodes in Jenkins.                           |
 | `get_node`                 | Get a specific node by name.                        |
 | `get_node_config`          | Get the configuration of a specific node.           |
+| `update_node_config`       | Update the configuration of a specific node.        |
 | `get_all_queue_items`      | Get all queue items in Jenkins.                     |
 | `get_queue_item`           | Get a specific queue item by ID.                    |
 | `cancel_queue_item`        | Cancel a specific queue item by ID.                 |

--- a/src/mcp_jenkins/server/item.py
+++ b/src/mcp_jenkins/server/item.py
@@ -42,6 +42,17 @@ async def get_item_config(ctx: Context, fullname: str) -> str:
     return jenkins(ctx).get_item_config(fullname=fullname)
 
 
+@mcp.tool(tags=['write'])
+async def update_item_config(ctx: Context, fullname: str, config: str) -> None:
+    """Update item configuration in Jenkins
+
+    Args:
+        fullname: The fullname of the item
+        config: The new configuration as an XML string
+    """
+    jenkins(ctx).update_item_config(fullname=fullname, config=config)
+
+
 @mcp.tool(tags=['read'])
 async def query_items(
     ctx: Context,

--- a/src/mcp_jenkins/server/node.py
+++ b/src/mcp_jenkins/server/node.py
@@ -40,3 +40,14 @@ async def get_node_config(ctx: Context, name: str) -> str:
         The config of the node
     """
     return jenkins(ctx).get_node_config(name=name)
+
+
+@mcp.tool(tags=['write'])
+async def update_node_config(ctx: Context, name: str, config: str) -> None:
+    """Update node configuration in Jenkins
+
+    Args:
+        name: The name of the node
+        config: The new configuration as an XML string
+    """
+    jenkins(ctx).update_node_config(name=name, config=config)

--- a/tests/test_server/test_item.py
+++ b/tests/test_server/test_item.py
@@ -47,6 +47,18 @@ async def test_get_item_config(mock_jenkins, mocker):
 
 
 @pytest.mark.asyncio
+async def test_update_item_config(mock_jenkins, mocker):
+    config_xml = '<project><description>Updated</description></project>'
+    mock_jenkins.update_item_config.return_value = None
+
+    await item.update_item_config.fn(mocker.Mock(), fullname='job1', config=config_xml)
+
+    mock_jenkins.update_item_config.assert_called_once_with(
+        fullname='job1', config=config_xml
+    )
+
+
+@pytest.mark.asyncio
 async def test_query_items(mock_jenkins, mocker):
     mock_jenkins.query_items.return_value = [
         Job(fullname='job1', color='blue', name='job1', url='1', class_='Job'),

--- a/tests/test_server/test_node.py
+++ b/tests/test_server/test_node.py
@@ -41,3 +41,15 @@ async def test_get_node(mock_jenkins, mocker):
 async def test_get_node_config(mock_jenkins, mocker):
     mock_jenkins.get_node_config.return_value = '<node>config</node>'
     assert await node.get_node_config.fn(mocker.Mock(), name='node1') == '<node>config</node>'
+
+
+@pytest.mark.asyncio
+async def test_update_node_config(mock_jenkins, mocker):
+    config_xml = '<slave><description>Updated</description></slave>'
+    mock_jenkins.update_node_config.return_value = None
+
+    await node.update_node_config.fn(mocker.Mock(), name='node1', config=config_xml)
+
+    mock_jenkins.update_node_config.assert_called_once_with(
+        name='node1', config=config_xml
+    )


### PR DESCRIPTION
# Add Config Update Tools for Items and Nodes                                                                         
  ## Overview                                                                                                             This PR adds two new MCP tools to update Jenkins configurations:
  - `update_item_config` - Update job/item XML configurations
  - `update_node_config` - Update node XML configurations

  ## Changes

  ### New Features
  - Added `update_item_config()` client method with XML validation
  - Added `update_node_config()` client method with XML validation
  - Added `update_item_config` MCP tool (tagged as `write`)
  - Added `update_node_config` MCP tool (tagged as `write`)
  - Added `_validate_xml()` helper for XML syntax validation
  - Extended `request()` method to support request body data

  ### Key Features
  - ✅ XML syntax validation before sending to Jenkins (fail fast)
  - ✅ CSRF protection via automatic crumb headers
  - ✅ Automatically hidden in read-only mode
  - ✅ Accepts config as XML string parameter
  - ✅ Follows existing three-layer architecture pattern

  ## Testing
  All tests passing:
  pytest tests/ -v
  42 passed, 29 skipped

  ### New Tests Added
  - `test_update_item_config` - Verifies item config updates with valid XML
  - `test_update_item_config_invalid_xml` - Tests XML validation for items
  - `test_update_node_config` - Verifies node config updates with valid XML
  - `test_update_node_config_invalid_xml` - Tests XML validation for nodes
  - Server layer integration tests for both tools

  ## Files Modified
  - `src/mcp_jenkins/jenkins/rest_client.py` - Core client implementation
  - `src/mcp_jenkins/server/item.py` - Item update tool
  - `src/mcp_jenkins/server/node.py` - Node update tool
  - `tests/test_jenkins/test_rest_client.py` - Client layer tests
  - `tests/test_server/test_item.py` - Server layer tests
  - `tests/test_server/test_node.py` - Server layer tests
  - `README.md` - Updated Available Tools table

  ## Example Usage

  ### Get and Update Item Config
  ```python
  # Get current config
  config = jenkins.get_item_config(fullname='my-job')

  # Modify XML
  import xml.etree.ElementTree as ET
  root = ET.fromstring(config)
  root.find('description').text = 'Updated description'
  modified = ET.tostring(root, encoding='unicode')

  # Update config
  jenkins.update_item_config(fullname='my-job', config=modified)