### PR TITLE
Fallback to None for Jenkins credentials if not set

### DIFF
--- a/src/mcp_jenkins/core/lifespan.py
+++ b/src/mcp_jenkins/core/lifespan.py
@@ -56,9 +56,10 @@ def jenkins(ctx: Context) -> Jenkins:
     try:
         requests = get_http_request()
 
-        jenkins_url = getattr(requests.state, 'jenkins_url', jenkins_url)
-        jenkins_username = getattr(requests.state, 'jenkins_username', jenkins_username)
-        jenkins_password = getattr(requests.state, 'jenkins_password', jenkins_password)
+        jenkins_url = getattr(requests.state, 'jenkins_url', None) or jenkins_url
+        jenkins_username = getattr(requests.state, 'jenkins_username', None) or jenkins_username
+        jenkins_password = getattr(requests.state, 'jenkins_password', None) or jenkins_password
+
 
         logger.debug(f'Retrieved Jenkins auth from request state - url: {jenkins_url}, username: {jenkins_username}')
     except RuntimeError as e:


### PR DESCRIPTION
The AuthMiddleware in the mcp-jenkins image has a bug: it always writes jenkins_url = None, jenkins_username = None, jenkins_password = None into the request state, even when no HTTP headers are present.