### PR TITLE
fix: retry request with fresh crumb on HTTP 403 (stale session)

### DIFF
--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -87,7 +87,22 @@ class Jenkins:
         url = self.endpoint_url(endpoint)
         logger.debug(f'Sending [{method}] request to {url}')
 
-        response = self._session.request(method=method, url=url, headers=headers, params=params, data=data)
+        response = self._session.request(
+            method=method, url=url, headers=headers, params=params, data=data, timeout=self.timeout,
+        )
+
+        # When a Jenkins HTTP session expires the cached CSRF crumb becomes
+        # invalid and every POST returns 403.  Retry once with a fresh crumb
+        # before giving up — this covers the stale-session case while still
+        # surfacing genuine permission errors on the second attempt.
+        if crumb and response.status_code == 403 and self._crumb_header:
+            logger.warning('Received 403 with a cached crumb — refreshing crumb and retrying the request')
+            self._crumb_header = None
+            headers.update(self.crumb_header)
+            response = self._session.request(
+                method=method, url=url, headers=headers, params=params, data=data, timeout=self.timeout,
+            )
+
         response.raise_for_status()
 
         return response

--- a/tests/test_jenkins/test_rest_client.py
+++ b/tests/test_jenkins/test_rest_client.py
@@ -56,6 +56,7 @@ class TestRequest:
             },
             params=None,
             data=None,
+            timeout=75,
         )
 
     def test_request_without_crumb(self, jenkins, mock_session):
@@ -69,6 +70,7 @@ class TestRequest:
             },
             params=None,
             data=None,
+            timeout=75,
         )
 
 
@@ -109,6 +111,105 @@ class TestCrumbHeader:
             _ = jenkins.crumb_header
 
 
+class TestCrumbRetry:
+    def test_retry_on_403_refreshes_crumb(self, mock_session, mocker):
+        j = Jenkins(url='https://example.com/', username='username', password='password')
+        # Simulate stale crumb cached from earlier
+        j._crumb_header = {'Jenkins-Crumb': 'stale-crumb'}
+
+        forbidden_resp = mocker.Mock(status_code=403)
+        forbidden_resp.raise_for_status.side_effect = HTTPError(response=forbidden_resp)
+
+        success_resp = mocker.Mock(status_code=201)
+        success_resp.raise_for_status.return_value = None
+
+        crumb_resp = mocker.Mock(
+            status_code=200,
+            json=lambda: {'crumbRequestField': 'Jenkins-Crumb', 'crumb': 'fresh-crumb'},
+        )
+        crumb_resp.raise_for_status.return_value = None
+
+        # First POST → 403, crumb refresh GET → new crumb, retry POST → 201
+        mock_session.request.side_effect = [forbidden_resp, crumb_resp, success_resp]
+
+        result = j.request('POST', 'job/test/build')
+
+        assert result.status_code == 201
+        assert j._crumb_header == {'Jenkins-Crumb': 'fresh-crumb'}
+        assert mock_session.request.call_count == 3
+
+    def test_no_retry_when_crumb_was_empty(self, mock_session, mocker):
+        j = Jenkins(url='https://example.com/', username='username', password='password')
+        # Empty crumb (CSRF disabled) — should NOT retry on 403
+        j._crumb_header = {}
+
+        forbidden_resp = mocker.Mock(status_code=403)
+        forbidden_resp.raise_for_status.side_effect = HTTPError(response=forbidden_resp)
+        mock_session.request.return_value = forbidden_resp
+
+        with pytest.raises(HTTPError):
+            j.request('POST', 'job/test/build')
+
+        assert mock_session.request.call_count == 1
+
+    def test_no_retry_on_non_403_errors(self, mock_session, mocker):
+        """Server errors (500, 401, etc.) must not trigger the crumb retry path."""
+        j = Jenkins(url='https://example.com/', username='username', password='password')
+        j._crumb_header = {'Jenkins-Crumb': 'some-crumb'}
+
+        for status in (401, 500, 502):
+            mock_session.reset_mock()
+            error_resp = mocker.Mock(status_code=status)
+            error_resp.raise_for_status.side_effect = HTTPError(response=error_resp)
+            mock_session.request.return_value = error_resp
+
+            with pytest.raises(HTTPError):
+                j.request('POST', 'job/test/build')
+
+            # Only 1 call — no retry
+            assert mock_session.request.call_count == 1
+
+    def test_no_retry_when_crumb_is_false(self, mock_session, mocker):
+        """Requests with crumb=False must never trigger the retry path, even on 403."""
+        j = Jenkins(url='https://example.com/', username='username', password='password')
+        j._crumb_header = {'Jenkins-Crumb': 'some-crumb'}
+
+        forbidden_resp = mocker.Mock(status_code=403)
+        forbidden_resp.raise_for_status.side_effect = HTTPError(response=forbidden_resp)
+        mock_session.request.return_value = forbidden_resp
+
+        with pytest.raises(HTTPError):
+            j.request('GET', 'crumbIssuer/api/json', crumb=False)
+
+        assert mock_session.request.call_count == 1
+
+    def test_retry_also_fails_raises_original_error(self, mock_session, mocker):
+        """When the retry request also returns 403, the error must propagate."""
+        j = Jenkins(url='https://example.com/', username='username', password='password')
+        j._crumb_header = {'Jenkins-Crumb': 'stale-crumb'}
+
+        forbidden_resp = mocker.Mock(status_code=403)
+        forbidden_resp.raise_for_status.side_effect = HTTPError(response=forbidden_resp)
+
+        crumb_resp = mocker.Mock(
+            status_code=200,
+            json=lambda: {'crumbRequestField': 'Jenkins-Crumb', 'crumb': 'fresh-crumb'},
+        )
+        crumb_resp.raise_for_status.return_value = None
+
+        still_forbidden_resp = mocker.Mock(status_code=403)
+        still_forbidden_resp.raise_for_status.side_effect = HTTPError(response=still_forbidden_resp)
+
+        # First POST → 403, crumb refresh → ok, retry POST → still 403
+        mock_session.request.side_effect = [forbidden_resp, crumb_resp, still_forbidden_resp]
+
+        with pytest.raises(HTTPError) as exc_info:
+            j.request('POST', 'job/test/build')
+
+        assert exc_info.value.response.status_code == 403
+        assert mock_session.request.call_count == 3
+
+
 def test_parse_fullname(jenkins):
     assert jenkins._parse_fullname('job-name') == ('', 'job-name')
     assert jenkins._parse_fullname('folder/job-name') == ('job/folder/', 'job-name')
@@ -147,6 +248,7 @@ class TestView:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
     def test_get_view(self, jenkins, mock_session, mocker):
@@ -182,6 +284,7 @@ class TestView:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
     def test_get_view_nested(self, jenkins, mock_session, mocker):
@@ -209,6 +312,7 @@ class TestView:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
 
@@ -285,6 +389,7 @@ class TestQueue:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
 
@@ -328,6 +433,7 @@ class TestNode:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
     def test_get_node_master(self, jenkins, mock_session, mocker):
@@ -369,6 +475,7 @@ class TestNode:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
     def test_get_nodes(self, jenkins, mock_session, mocker):
@@ -413,6 +520,7 @@ class TestNode:
             },
             params=None,
             data='<node>new config</node>',
+            timeout=75,
         )
 
 
@@ -522,6 +630,7 @@ class TestBuild:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
     def test_get_build_replay(self, jenkins, mock_session, mocker):
@@ -563,6 +672,7 @@ class TestBuild:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
+            timeout=75,
         )
 
     def test_get_build_parameters_no_params(self, jenkins, mock_session, mocker):
@@ -815,6 +925,7 @@ class TestItem:
             },
             params=None,
             data='<project>new config</project>',
+            timeout=75,
         )
 
     def test_query_items(self, jenkins, mock_session, mocker):
@@ -893,4 +1004,5 @@ class TestItem:
             headers={'Jenkins-Crumb': 'crumb-value'},
             params={'param1': 'value1'},
             data=None,
+            timeout=75,
         )


### PR DESCRIPTION
## Problem

When mcp-jenkins runs as a long-lived MCP server, all POST requests start failing with:

`
403 No valid crumb was included in the request
`

This happens because Jenkins HTTP sessions expire (default ~30 minutes), but the cached CSRF crumb is tied to that session. Once the session is gone, the crumb is rejected — and the plugin never refreshes it.

This is the root cause behind #32.

## Root Cause

The `crumb_header` property (`rest_client.py`) caches the crumb in `self._crumb_header` on first fetch and **never invalidates it**. Since `requests.Session` persists the `JSESSIONID` cookie, the crumb is bound to a specific server-side session. After that session expires, every POST gets a 403 — permanently, until the MCP server is restarted.

In a typical MCP workflow the server stays alive for hours while the user works. The crumb becomes stale long before the session ends.

## Fix

**Retry once with a fresh crumb on 403.** This is the standard pattern (similar to OAuth token refresh):

1. Send request with cached crumb
2. If response is 403 **and** a crumb was used **and** CSRF is enabled:
   - Invalidate cached crumb (`self._crumb_header = None`)
   - Fetch a fresh crumb via `/crumbIssuer/api/json`
   - Retry the request exactly once
3. If the retry also fails — raise normally

The retry is **not** triggered when:
- `crumb=False` (e.g. the crumb-fetch request itself — no infinite loop)
- CSRF protection is disabled (`_crumb_header` is an empty dict)

### Why not other approaches?

| Approach | Downside |
|---|---|
| TTL-based cache expiry | Jenkins session timeout is configurable — no safe default |
| Always fetch fresh crumb | Extra HTTP request on **every** call, even when crumb is valid |
| "Use API tokens" (#32 workaround) | Not a fix — shifts burden to users, doesn't work in all Jenkins configs |

## Additional fix

`self.timeout` was declared in `__init__` but never passed to `self._session.request()` calls in the `request()` method. Fixed by adding `timeout=self.timeout` to all calls.

## Tests

Added 5 new tests in `TestCrumbRetry`:

| Test | What it verifies |
|---|---|
| `test_retry_on_403_refreshes_crumb` | Happy path: 403 → refresh → retry → 201 |
| `test_no_retry_when_crumb_was_empty` | CSRF disabled (empty dict) → no retry |
| `test_no_retry_on_non_403_errors` | 401/500/502 → no retry (only 403 triggers it) |
| `test_no_retry_when_crumb_is_false` | `crumb=False` → no retry |
| `test_retry_also_fails_raises_original_error` | Retry also 403 → error propagates correctly |

All 91 tests pass (86 existing + 5 new).

## Changes

- `src/mcp_jenkins/jenkins/rest_client.py` — crumb retry logic + timeout forwarding (+17 lines)
- `tests/test_jenkins/test_rest_client.py` — 5 new tests + updated 13 existing assertions for timeout param (+128 lines)

Fixes #32