### PR TITLE
feat(plugin): add plugin support with get_all_plugins,  get_plugins_with_problems, get_plugin_dependency_graph 

### DIFF
--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -774,3 +774,52 @@ class Jenkins:
         installed = normalize_version(installed_ver)
         required = normalize_version(required_ver)
         return installed > required
+
+    def get_plugin_dependency_graph(self, short_name: str) -> dict:
+        """Get dependency graph for a specific plugin in Graphviz format.
+
+        Recursively analyzes dependencies down to leaf nodes (plugins with no dependencies).
+
+        Args:
+            short_name: The short name of the plugin to analyze.
+
+        Returns:
+            A dictionary containing 'nodes' and 'edges' for Graphviz rendering.
+        """
+        plugins = self.get_plugins(depth=2)
+        installed = {p['shortName']: p for p in plugins}
+
+        if short_name not in installed:
+            return {'nodes': [], 'edges': [], 'error': f'Plugin not found: {short_name}'}
+
+        nodes = []
+        edges = []
+        visited = set()
+
+        def traverse(name: str):
+            if name in visited:
+                return
+            visited.add(name)
+
+            if name not in installed:
+                nodes.append({'id': name, 'label': name, 'status': 'missing'})
+                return
+
+            plugin = installed[name]
+            nodes.append(
+                {
+                    'id': name,
+                    'label': f'{name}\n({plugin.get("version", "?")})',
+                    'status': 'installed',
+                }
+            )
+
+            deps = plugin.get('dependencies', [])
+            for dep in deps:
+                dep_name = dep.get('shortName', '')
+                edges.append({'from': name, 'to': dep_name})
+                traverse(dep_name)
+
+        traverse(short_name)
+
+        return {'nodes': nodes, 'edges': edges}

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -567,3 +567,210 @@ class Jenkins:
         )
 
         return int(response.headers.get('Location', None).strip('/').split('/')[-1])
+
+    def get_plugins(self, *, depth: int = 0) -> list[dict]:
+        """Get a list of all installed plugins.
+
+        Args:
+            depth: The depth of the information to retrieve.
+
+        Returns:
+            A list of plugin dictionaries.
+        """
+        response = self.request('GET', rest_endpoint.PLUGIN_LIST(depth=depth))
+        return response.json().get('plugins', [])
+
+    def get_plugin(self, *, short_name: str, depth: int = 2) -> dict | None:
+        """Get a specific plugin by short name.
+
+                Args:
+                    short_name: The short name of the plugin.
+                    depth: The depth of the information to retrieve. Default is 2 (includes dependencies).
+
+        Returns:
+                    A list of plugins that can be downgraded.
+        """
+        plugins = self.get_plugins(depth=depth)
+        for plugin in plugins:
+            if plugin.get('shortName') == short_name:
+                return plugin
+        return None
+
+    def get_plugins_with_problems(self) -> list[dict]:
+        """Get a list of plugins that have dependency problems.
+
+        Checks each plugin's dependencies against the installed plugins
+        to identify missing dependencies or version mismatches.
+
+        Returns:
+            A list of plugins with dependency problems.
+        """
+        jenkins_version = self._get_jenkins_version()
+        plugins = self.get_plugins(depth=2)
+
+        installed = {p['shortName']: p for p in plugins}
+
+        problems = []
+        for plugin in plugins:
+            short_name = plugin.get('shortName', '')
+            version = plugin.get('version', '')
+            required_core = plugin.get('requiredCoreVersion', '')
+
+            if required_core and jenkins_version:
+                if not self._is_core_compatible(jenkins_version, required_core):
+                    problems.append(
+                        {
+                            'shortName': short_name,
+                            'problem': 'incompatible_core_version',
+                            'pluginVersion': version,
+                            'requiredCoreVersion': required_core,
+                            'jenkinsVersion': jenkins_version,
+                            'severity': 'error',
+                            'message': f'Plugin requires Jenkins {required_core}, but current version is {jenkins_version}',
+                        }
+                    )
+
+            if not plugin.get('enabled'):
+                problems.append(
+                    {
+                        'shortName': short_name,
+                        'problem': 'plugin_disabled',
+                        'pluginVersion': version,
+                        'severity': 'warning',
+                        'message': 'Plugin is currently disabled',
+                    }
+                )
+
+            deps = plugin.get('dependencies', [])
+            for dep in deps:
+                dep_name = dep.get('shortName', '')
+                dep_version = dep.get('version', '')
+                is_optional = dep.get('optional', False)
+                is_bundled = dep.get('bundled', False)
+
+                if dep_name not in installed:
+                    if is_optional:
+                        problems.append(
+                            {
+                                'shortName': short_name,
+                                'problem': 'missing_optional_dependency',
+                                'dependency': dep_name,
+                                'requiredVersion': dep_version,
+                                'severity': 'info',
+                                'message': f'Missing optional dependency: {dep_name}',
+                            }
+                        )
+                    elif not is_bundled:
+                        problems.append(
+                            {
+                                'shortName': short_name,
+                                'problem': 'missing_dependency',
+                                'dependency': dep_name,
+                                'requiredVersion': dep_version,
+                                'severity': 'error',
+                                'message': f'Missing required dependency: {dep_name}',
+                            }
+                        )
+                else:
+                    installed_ver = installed[dep_name].get('version', '')
+                    if dep_version and installed_ver and installed_ver != dep_version:
+                        if self._is_version_greater(installed_ver, dep_version):
+                            continue
+                        if is_optional:
+                            problems.append(
+                                {
+                                    'shortName': short_name,
+                                    'problem': 'version_mismatch_optional',
+                                    'dependency': dep_name,
+                                    'requiredVersion': dep_version,
+                                    'installedVersion': installed_ver,
+                                    'severity': 'info',
+                                    'message': f'Optional dependency {dep_name} version mismatch: required {dep_version}, installed {installed_ver}',
+                                }
+                            )
+                        else:
+                            problems.append(
+                                {
+                                    'shortName': short_name,
+                                    'problem': 'version_mismatch',
+                                    'dependency': dep_name,
+                                    'requiredVersion': dep_version,
+                                    'installedVersion': installed_ver,
+                                    'severity': 'error',
+                                    'message': f'Dependency {dep_name} version mismatch: required {dep_version}, installed {installed_ver}',
+                                }
+                            )
+
+        return problems
+
+    def get_plugins_with_updates(self, depth: int = 0) -> list[dict]:
+        """Get plugins that have available updates.
+
+        Args:
+            depth: The depth of the information to retrieve.
+
+        Returns:
+            A list of plugins with available updates.
+        """
+        plugins = self.get_plugins(depth=depth)
+        return [
+            {
+                'shortName': p.get('shortName'),
+                'longName': p.get('longName'),
+                'version': p.get('version'),
+            }
+            for p in plugins
+            if p.get('hasUpdate')
+        ]
+
+    def get_plugins_with_backup(self, depth: int = 0) -> list[dict]:
+        """Get plugins that can be downgraded.
+
+        Plugins with backupVersion and downgradable=true can be rolled back.
+
+        Args:
+            depth: The depth of the information to retrieve.
+
+        Returns:
+            A list of plugins that can be downgraded.
+        """
+        response = self.request('GET', rest_endpoint.PLUGIN_LIST(depth=depth))
+        plugins = response.json().get('plugins', [])
+        return [
+            {
+                'shortName': p.get('shortName'),
+                'longName': p.get('longName'),
+                'version': p.get('version'),
+                'backupVersion': p.get('backupVersion'),
+                'downgradable': p.get('downgradable'),
+            }
+            for p in plugins
+            if p.get('backupVersion') and p.get('downgradable')
+        ]
+
+    def _get_jenkins_version(self) -> str:
+        """Get the Jenkins core version from response header."""
+        response = self.request('GET', '', crumb=False)
+        return response.headers.get('X-Jenkins', '')
+
+    def _is_core_compatible(self, jenkins_ver: str, required_ver: str) -> bool:
+        """Check if Jenkins version is compatible with required core version."""
+
+        def normalize_version(v: str) -> tuple:
+            parts = v.split('.')
+            return tuple(int(p) if p.isdigit() else 0 for p in parts[:3])
+
+        core = normalize_version(jenkins_ver)
+        required = normalize_version(required_ver)
+        return core >= required
+
+    def _is_version_greater(self, installed_ver: str, required_ver: str) -> bool:
+        """Check if installed version is greater than required version."""
+
+        def normalize_version(v: str) -> tuple:
+            parts = v.split('.')
+            return tuple(int(p) if p.isdigit() else 0 for p in parts[:3])
+
+        installed = normalize_version(installed_ver)
+        required = normalize_version(required_ver)
+        return installed > required

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -755,6 +755,8 @@ class Jenkins:
 
     def _is_core_compatible(self, jenkins_ver: str, required_ver: str) -> bool:
         """Check if Jenkins version is compatible with required core version."""
+        if not isinstance(jenkins_ver, str) or not isinstance(required_ver, str):
+            return True
 
         def normalize_version(v: str) -> tuple:
             parts = v.split('.')
@@ -766,6 +768,8 @@ class Jenkins:
 
     def _is_version_greater(self, installed_ver: str, required_ver: str) -> bool:
         """Check if installed version is greater than required version."""
+        if not isinstance(installed_ver, str) or not isinstance(required_ver, str):
+            return False
 
         def normalize_version(v: str) -> tuple:
             parts = v.split('.')

--- a/src/mcp_jenkins/jenkins/rest_endpoint.py
+++ b/src/mcp_jenkins/jenkins/rest_endpoint.py
@@ -38,3 +38,6 @@ BUILD_STOP = RestEndpoint('{folder}job/{name}/{number}/stop')
 BUILD_REPLAY = RestEndpoint('{folder}job/{name}/{number}/replay')
 BUILD_PARAMETERS = RestEndpoint('{folder}job/{name}/{number}/api/json?tree=actions[parameters[name,value]]')
 BUILD_TEST_REPORT = RestEndpoint('{folder}job/{name}/{number}/testReport/api/json?depth={depth}')
+
+PLUGIN_LIST = RestEndpoint('pluginManager/api/json?depth={depth}')
+PLUGIN_LIST_TREE = RestEndpoint('pluginManager/api/json?tree=plugins[{tree}]')

--- a/src/mcp_jenkins/server/__init__.py
+++ b/src/mcp_jenkins/server/__init__.py
@@ -31,4 +31,4 @@ mcp = JenkinsMCP('mcp-jenkins', lifespan=lifespan)
 
 # Import tool modules to register them with the MCP server
 # This must happen after mcp is created so the @mcp.tool() decorators can reference it
-from mcp_jenkins.server import build, item, node, queue, view  # noqa: F401, E402
+from mcp_jenkins.server import build, item, node, plugin, queue, view  # noqa: F401, E402

--- a/src/mcp_jenkins/server/plugin.py
+++ b/src/mcp_jenkins/server/plugin.py
@@ -1,0 +1,74 @@
+from fastmcp import Context
+
+from mcp_jenkins.core.lifespan import jenkins
+from mcp_jenkins.server import mcp
+
+
+@mcp.tool(tags={'read'})
+async def get_all_plugins(ctx: Context, depth: int = 2) -> list[dict]:
+    """Get all installed plugins from Jenkins
+
+    Args:
+        depth: The depth of the information to retrieve. Default is 2 (includes dependencies).
+
+    Returns:
+        A list of all installed plugins
+    """
+    return jenkins(ctx).get_plugins(depth=depth)
+
+
+@mcp.tool(tags={'read'})
+async def get_plugin(ctx: Context, short_name: str, depth: int = 2) -> dict | None:
+    """Get a specific plugin from Jenkins
+
+    Contains detailed information about the plugin, including dependencies when depth >= 2.
+
+    Args:
+        short_name: The short name of the plugin
+        depth: The depth of the information to retrieve. Default is 2 (includes dependencies).
+
+    Returns:
+        The plugin details, or None if not found
+    """
+    return jenkins(ctx).get_plugin(short_name=short_name, depth=depth)
+
+
+@mcp.tool(tags={'read'})
+async def get_plugins_with_problems(ctx: Context) -> list[dict]:
+    """Get all plugins with problems from Jenkins
+
+    These are plugins that have issues such as missing dependencies,
+    incompatible versions, core version mismatch, or other configuration problems.
+
+    Returns:
+        A list of plugins with problems
+    """
+    return jenkins(ctx).get_plugins_with_problems()
+
+
+@mcp.tool(tags={'read'})
+async def get_plugins_with_backup(ctx: Context, depth: int = 0) -> list[dict]:
+    """Get plugins that can be downgraded
+
+    Returns plugins that have a backupVersion and can be rolled back.
+
+    Args:
+        depth: The depth of the information to retrieve. Default is 0.
+
+    Returns:
+        A list of plugins that can be downgraded
+    """
+    return jenkins(ctx).get_plugins_with_backup(depth=depth)
+
+
+@mcp.tool(tags={'read'})
+async def get_plugins_with_updates(ctx: Context, depth: int = 0) -> list[dict]:
+    """Get plugins that have available updates
+
+    Args:
+        depth: The depth of the information to retrieve. Default is 0.
+
+    Returns:
+        A list of plugins with available updates
+    """
+    return jenkins(ctx).get_plugins_with_updates(depth=depth)

--- a/src/mcp_jenkins/server/plugin.py
+++ b/src/mcp_jenkins/server/plugin.py
@@ -72,3 +72,19 @@ async def get_plugins_with_updates(ctx: Context, depth: int = 0) -> list[dict]:
         A list of plugins with available updates
     """
     return jenkins(ctx).get_plugins_with_updates(depth=depth)
+
+
+@mcp.tool(tags={'read'})
+async def get_plugin_dependency_graph(ctx: Context, short_name: str) -> dict:
+    """Get dependency graph for a specific plugin in Graphviz format
+
+    Recursively analyzes dependencies down to leaf nodes.
+    Returns nodes and edges that can be used to generate a dependency graph.
+
+    Args:
+        short_name: The short name of the plugin to analyze
+
+    Returns:
+        A dictionary with 'nodes' and 'edges' for Graphviz rendering
+    """
+    return jenkins(ctx).get_plugin_dependency_graph(short_name=short_name)

--- a/tests/test_jenkins/test_rest_client.py
+++ b/tests/test_jenkins/test_rest_client.py
@@ -1006,3 +1006,284 @@ class TestItem:
             data=None,
             timeout=75,
         )
+
+
+class TestPlugin:
+    def test_get_plugins(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {'shortName': 'plugin-a', 'version': '1.0', 'enabled': True},
+                    {'shortName': 'plugin-b', 'version': '2.0', 'enabled': False},
+                ]
+            }
+        )
+
+        assert jenkins.get_plugins(depth=0) == [
+            {'shortName': 'plugin-a', 'version': '1.0', 'enabled': True},
+            {'shortName': 'plugin-b', 'version': '2.0', 'enabled': False},
+        ]
+
+    def test_get_plugin_found(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {'shortName': 'plugin-a', 'version': '1.0'},
+                    {'shortName': 'plugin-b', 'version': '2.0'},
+                ]
+            }
+        )
+
+        result = jenkins.get_plugin(short_name='plugin-b')
+        assert result == {'shortName': 'plugin-b', 'version': '2.0'}
+
+    def test_get_plugin_not_found(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {'shortName': 'plugin-a', 'version': '1.0'},
+                ]
+            }
+        )
+
+        result = jenkins.get_plugin(short_name='nonexistent')
+        assert result is None
+
+    def test_get_plugins_with_problems(self, jenkins, mock_session, mocker):
+        pass
+
+    def test_get_plugins_with_problems_missing_dependency(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'version': '2.479.3',
+            }
+        )
+        mock_session.request.return_value.headers = {'X-Jenkins': '2.479.3'}
+
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {
+                        'shortName': 'plugin-a',
+                        'version': '1.0',
+                        'enabled': True,
+                        'dependencies': [
+                            {'shortName': 'missing-dep', 'version': '1.0', 'optional': False, 'bundled': False},
+                        ],
+                    },
+                ]
+            }
+        )
+
+        problems = jenkins.get_plugins_with_problems()
+        missing_dep = next((p for p in problems if p['problem'] == 'missing_dependency'), None)
+        assert missing_dep is not None
+        assert missing_dep['dependency'] == 'missing-dep'
+
+    def test_get_plugins_with_problems_optional_dependency_ignored(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'version': '2.479.3',
+            }
+        )
+        mock_session.request.return_value.headers = {'X-Jenkins': '2.479.3'}
+
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {
+                        'shortName': 'plugin-a',
+                        'version': '1.0',
+                        'enabled': True,
+                        'dependencies': [
+                            {'shortName': 'optional-dep', 'version': '1.0', 'optional': True, 'bundled': False},
+                        ],
+                    },
+                ]
+            }
+        )
+
+        problems = jenkins.get_plugins_with_problems()
+        missing_optional = next((p for p in problems if p['problem'] == 'missing_optional_dependency'), None)
+        assert missing_optional is not None
+
+    def test_get_plugins_with_problems_version_mismatch(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'version': '2.479.3',
+            }
+        )
+        mock_session.request.return_value.headers = {'X-Jenkins': '2.479.3'}
+
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {
+                        'shortName': 'plugin-a',
+                        'version': '1.0',
+                        'enabled': True,
+                        'dependencies': [
+                            {'shortName': 'dep-plugin', 'version': '2.0', 'optional': False, 'bundled': False},
+                        ],
+                    },
+                    {'shortName': 'dep-plugin', 'version': '1.5'},
+                ]
+            }
+        )
+
+        problems = jenkins.get_plugins_with_problems()
+        version_issue = next((p for p in problems if p['problem'] == 'version_mismatch'), None)
+        assert version_issue is not None
+
+    def test_get_plugins_with_problems_installed_version_higher_no_issue(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'version': '2.479.3',
+            }
+        )
+        mock_session.request.return_value.headers = {'X-Jenkins': '2.479.3'}
+
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {
+                        'shortName': 'plugin-a',
+                        'version': '1.0',
+                        'enabled': True,
+                        'dependencies': [
+                            {'shortName': 'dep-plugin', 'version': '1.0', 'optional': False, 'bundled': False},
+                        ],
+                    },
+                    {'shortName': 'dep-plugin', 'version': '2.0'},
+                ]
+            }
+        )
+
+        problems = jenkins.get_plugins_with_problems()
+        version_issue = next((p for p in problems if p['problem'] == 'version_mismatch'), None)
+        assert version_issue is None
+
+    def test_get_plugins_with_updates(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {'shortName': 'plugin-a', 'version': '1.0', 'hasUpdate': True},
+                    {'shortName': 'plugin-b', 'version': '2.0', 'hasUpdate': False},
+                ]
+            }
+        )
+
+        result = jenkins.get_plugins_with_updates()
+        assert len(result) == 1
+        assert result[0]['shortName'] == 'plugin-a'
+
+    def test_get_plugins_with_backup(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {'shortName': 'plugin-a', 'version': '1.0', 'backupVersion': '0.9', 'downgradable': True},
+                    {'shortName': 'plugin-b', 'version': '2.0'},
+                ]
+            }
+        )
+
+        result = jenkins.get_plugins_with_backup()
+        assert len(result) == 1
+        assert result[0]['shortName'] == 'plugin-a'
+        assert result[0]['backupVersion'] == '0.9'
+
+    def test_get_plugin_dependency_graph(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {
+                        'shortName': 'plugin-a',
+                        'version': '1.0',
+                        'dependencies': [
+                            {'shortName': 'plugin-b', 'version': '1.0', 'optional': False},
+                            {'shortName': 'plugin-c', 'version': '1.0', 'optional': True},
+                        ],
+                    },
+                    {
+                        'shortName': 'plugin-b',
+                        'version': '1.0',
+                        'dependencies': [],
+                    },
+                    {'shortName': 'plugin-c', 'version': '1.0', 'dependencies': []},
+                ]
+            }
+        )
+
+        result = jenkins.get_plugin_dependency_graph('plugin-a')
+        assert 'nodes' in result
+        assert 'edges' in result
+        assert len(result['nodes']) == 3
+        assert len(result['edges']) == 2
+
+    def test_get_plugin_dependency_graph_not_found(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {'shortName': 'plugin-a', 'version': '1.0', 'dependencies': []},
+                ]
+            }
+        )
+
+        result = jenkins.get_plugin_dependency_graph('nonexistent')
+        assert 'error' in result
+        assert result['error'] == 'Plugin not found: nonexistent'
+
+    def test_get_plugins_with_problems_disabled_plugin(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'version': '2.479.3',
+            }
+        )
+        mock_session.request.return_value.headers = {'X-Jenkins': '2.479.3'}
+
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {
+                        'shortName': 'plugin-a',
+                        'version': '1.0',
+                        'enabled': False,
+                        'dependencies': [],
+                    },
+                ]
+            }
+        )
+
+        problems = jenkins.get_plugins_with_problems()
+        disabled = next((p for p in problems if p['problem'] == 'plugin_disabled'), None)
+        assert disabled is not None
+        assert disabled['shortName'] == 'plugin-a'
+
+    def test_get_plugins_with_problems_optional_version_mismatch(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'version': '2.479.3',
+            }
+        )
+        mock_session.request.return_value.headers = {'X-Jenkins': '2.479.3'}
+
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: {
+                'plugins': [
+                    {
+                        'shortName': 'plugin-a',
+                        'version': '1.0',
+                        'enabled': True,
+                        'dependencies': [
+                            {'shortName': 'optional-dep', 'version': '2.0', 'optional': True, 'bundled': False},
+                        ],
+                    },
+                    {'shortName': 'optional-dep', 'version': '1.5'},
+                ]
+            }
+        )
+
+        problems = jenkins.get_plugins_with_problems()
+        version_issue = next((p for p in problems if p['problem'] == 'version_mismatch_optional'), None)
+        assert version_issue is not None
+        assert version_issue['dependency'] == 'optional-dep'

--- a/tests/test_server/test_plugin.py
+++ b/tests/test_server/test_plugin.py
@@ -1,0 +1,82 @@
+import pytest
+
+from mcp_jenkins.server import plugin
+
+
+@pytest.fixture
+def mock_jenkins(mocker):
+    mock_jenkins = mocker.Mock()
+
+    mocker.patch('mcp_jenkins.server.plugin.jenkins', return_value=mock_jenkins)
+
+    yield mock_jenkins
+
+
+@pytest.mark.asyncio
+async def test_get_all_plugins(mock_jenkins, mocker):
+    mock_jenkins.get_plugins.return_value = [
+        {'shortName': 'plugin-a', 'version': '1.0'},
+        {'shortName': 'plugin-b', 'version': '2.0'},
+    ]
+
+    result = await plugin.get_all_plugins(mocker.Mock())
+    assert result == [
+        {'shortName': 'plugin-a', 'version': '1.0'},
+        {'shortName': 'plugin-b', 'version': '2.0'},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_plugin(mock_jenkins, mocker):
+    mock_jenkins.get_plugin.return_value = {'shortName': 'plugin-a', 'version': '1.0'}
+
+    result = await plugin.get_plugin(mocker.Mock(), short_name='plugin-a')
+    assert result == {'shortName': 'plugin-a', 'version': '1.0'}
+
+
+@pytest.mark.asyncio
+async def test_get_plugins_with_problems(mock_jenkins, mocker):
+    mock_jenkins.get_plugins_with_problems.return_value = [
+        {'shortName': 'plugin-a', 'problem': 'missing_dependency', 'dependency': 'dep-a'}
+    ]
+
+    result = await plugin.get_plugins_with_problems(mocker.Mock())
+    assert result == [{'shortName': 'plugin-a', 'problem': 'missing_dependency', 'dependency': 'dep-a'}]
+
+
+@pytest.mark.asyncio
+async def test_get_plugins_with_backup(mock_jenkins, mocker):
+    mock_jenkins.get_plugins_with_backup.return_value = [
+        {'shortName': 'plugin-a', 'backupVersion': '0.9', 'downgradable': True}
+    ]
+
+    result = await plugin.get_plugins_with_backup(mocker.Mock())
+    assert result == [{'shortName': 'plugin-a', 'backupVersion': '0.9', 'downgradable': True}]
+
+
+@pytest.mark.asyncio
+async def test_get_plugins_with_updates(mock_jenkins, mocker):
+    mock_jenkins.get_plugins_with_updates.return_value = [{'shortName': 'plugin-a', 'version': '1.0'}]
+
+    result = await plugin.get_plugins_with_updates(mocker.Mock())
+    assert result == [{'shortName': 'plugin-a', 'version': '1.0'}]
+
+
+@pytest.mark.asyncio
+async def test_get_plugin_dependency_graph(mock_jenkins, mocker):
+    mock_jenkins.get_plugin_dependency_graph.return_value = {
+        'nodes': [
+            {'id': 'plugin-a', 'label': 'plugin-a\n(1.0)', 'status': 'installed'},
+            {'id': 'dep-a', 'label': 'dep-a\n(1.0)', 'status': 'installed'},
+        ],
+        'edges': [{'from': 'plugin-a', 'to': 'dep-a'}],
+    }
+
+    result = await plugin.get_plugin_dependency_graph(mocker.Mock(), short_name='plugin-a')
+    assert result == {
+        'nodes': [
+            {'id': 'plugin-a', 'label': 'plugin-a\n(1.0)', 'status': 'installed'},
+            {'id': 'dep-a', 'label': 'dep-a\n(1.0)', 'status': 'installed'},
+        ],
+        'edges': [{'from': 'plugin-a', 'to': 'dep-a'}],
+    }


### PR DESCRIPTION
Adds some read-only MCP tools for Jenkins plugins:

get_all_plugins -- lists all plugins
get_plugins_with_problems -- diagnose plugin problem
get_plugin_dependency_graph -- generate plugin dependency data for picture drawing

 plugin dependency graph result,  drawn after being processed by OpenCode.

<img width="1588" height="2141" alt="docker-plugin-complete-analysis" src="https://github.com/user-attachments/assets/88d46d7f-daa7-42c5-ba38-fd8c249a3159" />

