### PR TITLE
Harden Jenkins auth/SSL handling and document CI tool flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ uvx mcp-jenkins --transport streamable-http
 | `--host`                                                     | Host address for `streamable-http` transport. Default is `0.0.0.0`                                              | No       |
 | `--port`                                                     | Port number for `streamable-http` transport. Default is `9887`.                                                 | No       |
 
+### Environment Variables
+
+You can also provide Jenkins credentials via environment variables:
+
+- `jenkins_url` or `JENKINS_URL`
+- `jenkins_username` or `JENKINS_USERNAME` or `JENKINS_USER`
+- `jenkins_password` or `JENKINS_PASSWORD` or `JENKINS_TOKEN`
+- `jenkins_timeout` or `JENKINS_TIMEOUT`
+- `jenkins_verify_ssl` or `JENKINS_VERIFY_SSL`
+- `JENKINS_CA_BUNDLE` (path to a custom CA bundle file)
+
+`jenkins_verify_ssl` / `JENKINS_VERIFY_SSL` accepts `true` / `false`.
+If `JENKINS_CA_BUNDLE` is set, that file path is used as Requests `verify` value.
+
 ## Configuration and Usage
 
 ### Jetbrains Github Copilot
@@ -130,6 +144,27 @@ uvx mcp-jenkins \
 | `get_view`                 | Get a specific view by name.                        |
 | `get_all_views`          | Get the configuration of a specific view.           |
 
+
+## Typical CI Flow (Using MCP Tools)
+
+This is a common automation flow after pushing code:
+
+1. Find the job:
+   - `query_items(fullname_pattern=...)` or `get_item(fullname=...)`
+2. Trigger build:
+   - `build_item(fullname=..., build_type='build')`
+   - For parameterized jobs use `build_type='buildWithParameters'` with `params={...}`
+3. Track queue:
+   - `get_queue_item(id=<queue_id>)` until executable/build number is available
+4. Track build:
+   - `get_build(fullname=..., number=...)` until `building=false`
+5. Inspect results:
+   - `get_build_test_report(...)` for structured test counts (`failCount`, `passCount`, `skipCount`)
+   - `get_build_console_output(..., pattern='(FAIL|ERROR|Exception)', limit=...)` for fast log triage
+
+Notes:
+- Some Jenkins endpoints are permission-gated (for example plugin manager APIs).
+- On restricted roles, plugin tools may return permission errors while regular job/build tools still work.
 
 ## Contributing
 [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/src/mcp_jenkins/core/lifespan.py
+++ b/src/mcp_jenkins/core/lifespan.py
@@ -17,20 +17,24 @@ class LifespanContext(BaseModel):
     jenkins_username: str | None
     jenkins_password: str | None
     jenkins_timeout: int = 5
-    jenkins_verify_ssl: bool = True
+    jenkins_verify_ssl: bool | str = True
 
     jenkins_session_singleton: bool = True
 
 
 @asynccontextmanager
 async def lifespan(app: FastMCP[LifespanContext]) -> AsyncIterator['LifespanContext']:
-    jenkins_url = os.getenv('jenkins_url')
-    jenkins_username = os.getenv('jenkins_username')
-    jenkins_password = os.getenv('jenkins_password')
+    jenkins_url = _get_env('jenkins_url', 'JENKINS_URL')
+    jenkins_username = _get_env('jenkins_username', 'JENKINS_USERNAME', 'JENKINS_USER')
+    jenkins_password = _get_env('jenkins_password', 'JENKINS_PASSWORD', 'JENKINS_TOKEN')
 
-    jenkins_timeout = int(os.getenv('jenkins_timeout', '5'))
-    jenkins_verify_ssl = os.getenv('jenkins_verify_ssl', 'true').lower() == 'true'
-    jenkins_session_singleton = os.getenv('jenkins_session_singleton', 'true').lower() == 'true'
+    jenkins_timeout = int(_get_env('jenkins_timeout', 'JENKINS_TIMEOUT', default='5'))
+    jenkins_verify_ssl = _parse_verify_ssl(
+        _get_env('jenkins_verify_ssl', 'JENKINS_VERIFY_SSL', 'JENKINS_CA_BUNDLE', default='true')
+    )
+    jenkins_session_singleton = _get_env(
+        'jenkins_session_singleton', 'JENKINS_SESSION_SINGLETON', default='true'
+    ).lower() == 'true'
 
     yield LifespanContext(
         jenkins_url=jenkins_url,
@@ -72,7 +76,8 @@ def jenkins(ctx: Context) -> Jenkins:
         msg = (
             'Jenkins authentication details are missing. '
             'Please provide them via x-jenkins-* headers '
-            'or CLI arguments (--jenkins-url, --jenkins-username, --jenkins-password).'
+            'or CLI arguments (--jenkins-url, --jenkins-username, --jenkins-password), '
+            'or environment variables (jenkins_* / JENKINS_*).'
         )
         raise ValueError(msg)
 
@@ -90,3 +95,21 @@ def jenkins(ctx: Context) -> Jenkins:
     )
 
     return ctx.session.jenkins
+
+
+def _get_env(*keys: str, default: str | None = None) -> str | None:
+    for key in keys:
+        value = os.getenv(key)
+        if value:
+            return value
+    return default
+
+
+def _parse_verify_ssl(value: str) -> bool | str:
+    lowered = value.lower()
+    if lowered in ('true', '1', 'yes'):
+        return True
+    if lowered in ('false', '0', 'no'):
+        return False
+    # Any non-boolean value is treated as a CA bundle path for requests.Session.verify
+    return value

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -31,7 +31,7 @@ class Jenkins:
         username: str,
         password: str,
         timeout: int = 75,
-        verify_ssl: bool = True,
+        verify_ssl: bool | str = True,
     ) -> None:
         self.url = url
         self.timeout = timeout
@@ -91,11 +91,13 @@ class Jenkins:
             method=method, url=url, headers=headers, params=params, data=data, timeout=self.timeout,
         )
 
+        is_mutating = method.upper() not in ('GET', 'HEAD', 'OPTIONS')
+
         # When a Jenkins HTTP session expires the cached CSRF crumb becomes
         # invalid and every POST returns 403.  Retry once with a fresh crumb
         # before giving up — this covers the stale-session case while still
         # surfacing genuine permission errors on the second attempt.
-        if crumb and response.status_code == 403 and self._crumb_header:
+        if crumb and is_mutating and response.status_code == 403 and self._crumb_header:
             logger.warning('Received 403 with a cached crumb — refreshing crumb and retrying the request')
             self._crumb_header = None
             headers.update(self.crumb_header)
@@ -577,8 +579,17 @@ class Jenkins:
         Returns:
             A list of plugin dictionaries.
         """
-        response = self.request('GET', rest_endpoint.PLUGIN_LIST(depth=depth))
-        return response.json().get('plugins', [])
+        try:
+            response = self.request('GET', rest_endpoint.PLUGIN_LIST(depth=depth))
+            return response.json().get('plugins', [])
+        except HTTPError as e:
+            if e.response is not None and e.response.status_code in (401, 403):
+                msg = (
+                    'Cannot read plugin metadata: Jenkins denied access to pluginManager API '
+                    '(requires higher Jenkins permissions).'
+                )
+                raise PermissionError(msg) from e
+            raise
 
     def get_plugin(self, *, short_name: str, depth: int = 2) -> dict | None:
         """Get a specific plugin by short name.

--- a/tests/test_core/test_lifespan.py
+++ b/tests/test_core/test_lifespan.py
@@ -40,6 +40,43 @@ class TestLifespan:
             assert context.jenkins_verify_ssl is True
             assert context.jenkins_session_singleton is True
 
+    @pytest.mark.asyncio
+    async def test_lifespan_context_accepts_uppercase_aliases(self, mocker):
+        def getenv(key: str, default=None):
+            env = {
+                'JENKINS_URL': 'https://jenkins.uppercase.example.com',
+                'JENKINS_USER': 'upper-user',
+                'JENKINS_TOKEN': 'upper-token',
+                'JENKINS_TIMEOUT': '9',
+                'JENKINS_VERIFY_SSL': 'false',
+                'JENKINS_SESSION_SINGLETON': 'false',
+            }
+            return env.get(key, default)
+
+        mocker.patch('mcp_jenkins.core.lifespan.os', mocker.Mock(getenv=getenv))
+        async with lifespan(mocker.Mock) as context:
+            assert context.jenkins_url == 'https://jenkins.uppercase.example.com'
+            assert context.jenkins_username == 'upper-user'
+            assert context.jenkins_password == 'upper-token'
+            assert context.jenkins_timeout == 9
+            assert context.jenkins_verify_ssl is False
+            assert context.jenkins_session_singleton is False
+
+    @pytest.mark.asyncio
+    async def test_lifespan_context_accepts_ca_bundle_path(self, mocker):
+        def getenv(key: str, default=None):
+            env = {
+                'jenkins_url': 'https://jenkins.example.com',
+                'jenkins_username': 'username',
+                'jenkins_password': 'password',
+                'JENKINS_CA_BUNDLE': '/etc/ssl/certs/internal-ca.pem',
+            }
+            return env.get(key, default)
+
+        mocker.patch('mcp_jenkins.core.lifespan.os', mocker.Mock(getenv=getenv))
+        async with lifespan(mocker.Mock) as context:
+            assert context.jenkins_verify_ssl == '/etc/ssl/certs/internal-ca.pem'
+
 
 class TestJenkins:
     @pytest.fixture(autouse=True)

--- a/tests/test_jenkins/test_rest_client.py
+++ b/tests/test_jenkins/test_rest_client.py
@@ -209,6 +209,20 @@ class TestCrumbRetry:
         assert exc_info.value.response.status_code == 403
         assert mock_session.request.call_count == 3
 
+    def test_no_retry_on_get_even_with_cached_crumb(self, mock_session, mocker):
+        """GET requests should not trigger crumb refresh/retry loops."""
+        j = Jenkins(url='https://example.com/', username='username', password='password')
+        j._crumb_header = {'Jenkins-Crumb': 'some-crumb'}
+
+        forbidden_resp = mocker.Mock(status_code=403)
+        forbidden_resp.raise_for_status.side_effect = HTTPError(response=forbidden_resp)
+        mock_session.request.return_value = forbidden_resp
+
+        with pytest.raises(HTTPError):
+            j.request('GET', 'pluginManager/api/json?depth=0')
+
+        assert mock_session.request.call_count == 1
+
 
 def test_parse_fullname(jenkins):
     assert jenkins._parse_fullname('job-name') == ('', 'job-name')
@@ -1023,6 +1037,14 @@ class TestPlugin:
             {'shortName': 'plugin-a', 'version': '1.0', 'enabled': True},
             {'shortName': 'plugin-b', 'version': '2.0', 'enabled': False},
         ]
+
+    def test_get_plugins_permission_error(self, jenkins, mock_session, mocker):
+        forbidden_resp = mocker.Mock(status_code=403)
+        forbidden_resp.raise_for_status.side_effect = HTTPError(response=forbidden_resp)
+        mock_session.request.return_value = forbidden_resp
+
+        with pytest.raises(PermissionError, match='Cannot read plugin metadata'):
+            jenkins.get_plugins(depth=0)
 
     def test_get_plugin_found(self, jenkins, mock_session, mocker):
         mock_session.request.return_value = mocker.Mock(


### PR DESCRIPTION
## Summary
- support both lowercase and uppercase env var aliases for Jenkins credentials/config (`jenkins_*` and `JENKINS_*`), including `JENKINS_USER` and `JENKINS_TOKEN`
- support enterprise TLS chains via `JENKINS_CA_BUNDLE` by allowing `verify_ssl` to accept a CA bundle path
- avoid unnecessary crumb-refresh retries on read endpoints by retrying 403 only for mutating HTTP methods
- improve plugin API failure clarity by mapping `pluginManager` 401/403 to an explicit permission error
- add README guidance for env vars and a practical MCP build-monitoring flow (trigger -> queue -> build -> report/log triage)

## Why
- real-world Jenkins setups frequently use uppercase env vars and internal CAs
- restricted Jenkins roles can read jobs/builds but not plugin manager APIs; clearer error behavior helps operators
- the added README section makes it easier to apply tools in post-commit automation flows

## Validation
- `uv run pytest -q` -> `115 passed`

## Files
- `README.md`
- `src/mcp_jenkins/core/lifespan.py`
- `src/mcp_jenkins/jenkins/rest_client.py`
- `tests/test_core/test_lifespan.py`
- `tests/test_jenkins/test_rest_client.py`
