### PR TITLE
feat(script): add groovy script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ uvx mcp-jenkins \
 | `get_build_artifact_url`   | Get the direct URL of an artifact from a specific build. |
 | `get_view`                 | Get a specific view by name.                        |
 | `get_all_views`            | Get the configuration of a specific view.           |
+| `get_all_plugins`          | Get all installed plugins.                        |
+| `get_plugin`              | Get a specific plugin by short name.              |
+| `get_plugins_with_problems` | Get plugins with problems (missing dependencies, version mismatch, etc.). |
+| `get_plugins_with_backup`   | Get plugins that can be downgraded.               |
+| `get_plugins_with_updates` | Get plugins that have available updates.          |
+| `get_plugin_dependency_graph` | Get dependency graph for a plugin in Graphviz format. |
+| `run_groovy_script`       | Execute an arbitrary Groovy script on Jenkins.     |
 
 
 ## Contributing

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -896,3 +896,20 @@ class Jenkins:
         traverse(short_name)
 
         return {'nodes': nodes, 'edges': edges}
+
+    def run_script(self, script: str) -> str:  # noqa: N802
+        """Execute a Groovy script on Jenkins.
+
+        Args:
+            script: The Groovy script code to execute.
+
+        Returns:
+            The result of the script execution.
+        """
+        response = self.request('POST', rest_endpoint.SCRIPT_TEXT, data={'script': script.encode('utf-8')})
+
+        result = response.text
+        result_prefix = 'Result: '
+        if result.startswith(result_prefix):
+            return result[len(result_prefix) :].rstrip('\n')
+        return result

--- a/src/mcp_jenkins/jenkins/rest_endpoint.py
+++ b/src/mcp_jenkins/jenkins/rest_endpoint.py
@@ -43,3 +43,5 @@ BUILD_ARTIFACTS = RestEndpoint('{folder}job/{name}/{number}/api/json?tree=artifa
 
 PLUGIN_LIST = RestEndpoint('pluginManager/api/json?depth={depth}')
 PLUGIN_LIST_TREE = RestEndpoint('pluginManager/api/json?tree=plugins[{tree}]')
+
+SCRIPT_TEXT = RestEndpoint('scriptText')

--- a/src/mcp_jenkins/server/__init__.py
+++ b/src/mcp_jenkins/server/__init__.py
@@ -31,4 +31,4 @@ mcp = JenkinsMCP('mcp-jenkins', lifespan=lifespan)
 
 # Import tool modules to register them with the MCP server
 # This must happen after mcp is created so the @mcp.tool() decorators can reference it
-from mcp_jenkins.server import build, item, node, plugin, queue, view  # noqa: F401, E402
+from mcp_jenkins.server import build, item, node, plugin, queue, view, script  # noqa: F401, E402

--- a/src/mcp_jenkins/server/script.py
+++ b/src/mcp_jenkins/server/script.py
@@ -1,0 +1,32 @@
+from fastmcp import Context
+
+from mcp_jenkins.core.lifespan import jenkins
+from mcp_jenkins.server import mcp
+
+
+@mcp.tool(tags={'write'})
+async def run_groovy_script(ctx: Context, script: str) -> str:
+    """Execute an arbitrary Groovy script on Jenkins.
+
+    This tool provides access to Jenkins internal features that are not available via REST API.
+
+    Args:
+        script: The Groovy script code to execute.
+
+    Returns:
+        The result of the script execution.
+
+    Examples:
+        # Basic usage:
+        run_groovy_script(script='println Jenkins.instance.version')
+
+        # Access Jenkins information:
+        run_groovy_script(
+            script='''
+                def version = Jenkins.instance.version
+                def mode = Jenkins.instance.mode
+                return "Version: ${version}, Mode: ${mode}"
+            '''
+        )
+    """
+    return jenkins(ctx).run_script(script=script)

--- a/tests/test_jenkins/test_rest_client.py
+++ b/tests/test_jenkins/test_rest_client.py
@@ -1362,3 +1362,33 @@ class TestPlugin:
         version_issue = next((p for p in problems if p['problem'] == 'version_mismatch_optional'), None)
         assert version_issue is not None
         assert version_issue['dependency'] == 'optional-dep'
+
+    def test_run_script(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(text='Result: script output', raise_for_status=mocker.Mock())
+
+        result = jenkins.run_script('println("test")')
+
+        assert result == 'script output'
+        mock_session.request.assert_called_once_with(
+            method='POST',
+            url='https://example.com/scriptText',
+            headers={'Jenkins-Crumb': 'crumb-value'},
+            data={'script': b'println("test")'},
+            params=None,
+            timeout=75,
+        )
+
+    def test_run_script_without_result_prefix(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(text='direct output', raise_for_status=mocker.Mock())
+
+        result = jenkins.run_script('return "direct"')
+
+        assert result == 'direct output'
+        mock_session.request.assert_called_once_with(
+            method='POST',
+            url='https://example.com/scriptText',
+            headers={'Jenkins-Crumb': 'crumb-value'},
+            data={'script': b'return "direct"'},
+            params=None,
+            timeout=75,
+        )

--- a/tests/test_server/test_script.py
+++ b/tests/test_server/test_script.py
@@ -1,0 +1,29 @@
+import pytest
+
+from mcp_jenkins.server import script
+
+
+@pytest.fixture
+def mock_jenkins(mocker):
+    mock_jenkins = mocker.Mock()
+    mocker.patch('mcp_jenkins.server.script.jenkins', return_value=mock_jenkins)
+    yield mock_jenkins
+
+
+@pytest.mark.asyncio
+async def test_run_groovy_script(mock_jenkins, mocker):
+    mock_jenkins.run_script.return_value = 'Script result: success'
+
+    result = await script.run_groovy_script(mocker.Mock(), script='println("test")')
+
+    assert result == 'Script result: success'
+    mock_jenkins.run_script.assert_called_once_with(script='println("test")')
+
+
+@pytest.mark.asyncio
+async def test_run_groovy_script_with_result_prefix(mock_jenkins, mocker):
+    mock_jenkins.run_script.return_value = 'output only'
+
+    result = await script.run_groovy_script(mocker.Mock(), script='return "output"')
+
+    assert result == 'output only'


### PR DESCRIPTION
Add the function of executing Groovy scripts as the fallback capability of the tools.
Jenkins can basically perform any operation through Groovy scripts.