### PR TITLE
feat: implement /healthz endpoint for HTTP healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,27 @@ uvx mcp-jenkins \
   --transport sse
 ```
 
+## Health Check Endpoint
+
+When running with `--transport streamable-http` or `--transport sse`, the server exposes a plain HTTP liveness endpoint:
+
+```
+GET /healthz  ->  200 OK
+```
+
+It always returns `200` and bypasses the `x-jenkins-*` auth headers, so it is safe to use directly as a Kubernetes liveness/readiness probe without any Jenkins credentials. Example probe:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 9887
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+Note: this is a liveness check only — it does not verify connectivity to the upstream Jenkins server.
+
 ## Available Tools
 | Tool                       | Description                                         |
 |----------------------------|-----------------------------------------------------|

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,7 +188,8 @@ EXPOSE 9887
 # - Python environment is working
 # - All dependencies are correctly installed
 # - mcp_jenkins module can be loaded
-# For HTTP-based healthcheck in SSE/streamable-http mode, implement /health endpoint
+# For HTTP-based healthcheck in SSE/streamable-http mode, the application exposes
+# GET /healthz endpoint (always returns 200)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD python3 -c "import mcp_jenkins" || exit 1
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
     # Health check configuration (matches Dockerfile healthcheck)
     # NOTE: This only verifies the module loads, not Jenkins connectivity.
-    # For SSE/HTTP mode, consider implementing a /health endpoint in the app.
+    # For SSE/streamable-http mode, the application exposes GET /healthz endpoint
     healthcheck:
       test: ["CMD-SHELL", "python3 -c 'import mcp_jenkins' || exit 1"]
       interval: 30s

--- a/src/mcp_jenkins/core/middleware.py
+++ b/src/mcp_jenkins/core/middleware.py
@@ -14,6 +14,11 @@ class AuthMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # Bypass auth handling for the health probe so kubernetes can poll it without headers
+        if scope.get('path') == '/healthz':
+            await self.app(scope, receive, send)
+            return
+
         # According to ASGI spec, middleware should copy scope when modifying it
         scope_copy: Scope = dict(scope)
 

--- a/src/mcp_jenkins/server/__init__.py
+++ b/src/mcp_jenkins/server/__init__.py
@@ -3,6 +3,8 @@ from typing import Any, Literal
 from fastmcp import FastMCP
 from starlette.applications import Starlette
 from starlette.middleware import Middleware as ASGIMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
 
 from mcp_jenkins.core import AuthMiddleware, LifespanContext, lifespan
 
@@ -28,6 +30,13 @@ class JenkinsMCP(FastMCP[LifespanContext]):
 
 
 mcp = JenkinsMCP('mcp-jenkins', lifespan=lifespan)
+
+
+@mcp.custom_route('/healthz', methods=['GET'])
+async def healthz(_request: Request) -> PlainTextResponse:
+    """Liveness probe endpoint. Always returns 200 for kubernetes health checks."""
+    return PlainTextResponse('OK', status_code=200)
+
 
 # Import tool modules to register them with the MCP server
 # This must happen after mcp is created so the @mcp.tool() decorators can reference it

--- a/tests/test_core/test_middleware.py
+++ b/tests/test_core/test_middleware.py
@@ -86,3 +86,21 @@ class TestAuthMiddleware:
         await middleware(scope, mock_receive, mock_send)
 
         mock_app.assert_called_once_with(scope, mock_receive, mock_send)
+
+    @pytest.mark.asyncio
+    async def test_call_healthz_bypass(self, mocker):
+        mock_app, mock_receive, mock_send = (
+            mocker.AsyncMock(),
+            mocker.AsyncMock(),
+            mocker.AsyncMock(),
+        )
+        middleware = AuthMiddleware(mock_app)
+
+        scope = {
+            'type': 'http',
+            'path': '/healthz',
+        }
+
+        await middleware(scope, mock_receive, mock_send)
+
+        mock_app.assert_called_once_with(scope, mock_receive, mock_send)

--- a/tests/test_server/test_server.py
+++ b/tests/test_server/test_server.py
@@ -1,4 +1,6 @@
-from mcp_jenkins.server import JenkinsMCP
+from starlette.testclient import TestClient
+
+from mcp_jenkins.server import JenkinsMCP, mcp
 
 
 def test_http_app(mocker):
@@ -8,3 +10,12 @@ def test_http_app(mocker):
     mocker.patch('mcp_jenkins.server.ASGIMiddleware', return_value=mock_wm)
 
     assert jm.http_app(path='/mcp', middleware=[mock_wm], transport='http').user_middleware.count(mock_wm) == 2
+
+
+def test_healthz_returns_200():
+    client = TestClient(mcp.http_app(transport='http'))
+
+    response = client.get('/healthz')
+
+    assert response.status_code == 200
+    assert response.text == 'OK'

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "mcp-jenkins"
-version = "3.1.1"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
 - Add `GET /healthz` on the Starlette HTTP app for liveness probes
 - Bypass `AuthMiddleware` for the endpoint
 - Add tests for the endpoint and the middleware bypass
 - Update `README.md` with usage examples

When running the MCP server in Kubernetes, it would be useful to have an endpoint for liveness/readiness probes.