### PR TITLE
feat: add get_build_console_tail, wait_for_build_completion, get_queue_to_build

### DIFF
--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -218,6 +218,22 @@ class Jenkins:
         response = self.request('GET', rest_endpoint.QUEUE_ITEM(id=id, depth=depth))
         return QueueItem.model_validate(response.json())
 
+    def get_queue_item_raw(self, *, id: int) -> dict:
+        """Get a queue item by its ID as raw JSON dict.
+
+        Use this when you need fields not present in the QueueItem model,
+        such as the 'build' field that appears when a queue item is
+        assigned to a running build.
+
+        Args:
+            id: The ID of the queue item.
+
+        Returns:
+            A dictionary representing the queue item as returned by Jenkins.
+        """
+        response = self.request('GET', rest_endpoint.QUEUE_ITEM(id=id, depth=1))
+        return response.json()
+
     def cancel_queue_item(self, *, id: int) -> None:
         """Cancel a queue item by its ID.
 
@@ -342,6 +358,34 @@ class Jenkins:
 
         response.close()
         return '\n'.join(matched)
+
+    def get_build_console_tail(
+        self,
+        *,
+        fullname: str,
+        number: int,
+        n_lines: int = 200,
+    ) -> str:
+        """Get the last N lines of a build's console output.
+
+        Args:
+            fullname: The fullname of the job.
+            number: The build number.
+            n_lines: Number of lines to return from the end (default: 200).
+
+        Returns:
+            Last N lines of console output as a string.
+        """
+        folder, name = self._parse_fullname(fullname)
+        response = self._session.get(
+            self.endpoint_url(rest_endpoint.BUILD_CONSOLE_OUTPUT(folder=folder, name=name, number=number)),
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+
+        all_lines = response.text.split('\n')
+        tail_lines = all_lines[-n_lines:] if len(all_lines) >= n_lines else all_lines
+        return '\n'.join(tail_lines)
 
     def stop_build(self, *, fullname: str, number: int) -> None:
         """Stop a running Jenkins build.

--- a/src/mcp_jenkins/server/build.py
+++ b/src/mcp_jenkins/server/build.py
@@ -1,4 +1,6 @@
+import asyncio
 import base64
+import time
 
 from fastmcp import Context
 
@@ -190,3 +192,70 @@ async def get_build_artifact_url(ctx: Context, fullname: str, relative_path: str
         number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
 
     return jenkins(ctx).get_build_artifact_url(fullname=fullname, number=number, relative_path=relative_path)
+
+
+@mcp.tool(tags=['read'])
+async def get_build_console_tail(
+    ctx: Context,
+    fullname: str,
+    number: int,
+    n_lines: int = 200,
+) -> str:
+    """Get the last N lines of a build's console output.
+
+    Args:
+        fullname: The fullname of the job
+        number: The build number
+        n_lines: Number of lines from the end (default: 200)
+
+    Returns:
+        Last N lines of console output
+    """
+    return jenkins(ctx).get_build_console_tail(fullname=fullname, number=number, n_lines=n_lines)
+
+
+@mcp.tool(tags=['read'])
+async def wait_for_build_completion(
+    ctx: Context,
+    fullname: str,
+    number: int,
+    timeout: int = 1800,
+    poll_interval: int = 30,
+) -> dict:
+    """Block until a build completes or timeout.
+
+    Server-side polling — agent calls once, gets result when done or timeout.
+
+    Args:
+        fullname: The fullname of the job
+        number: The build number
+        timeout: Max seconds to wait (default: 1800)
+        poll_interval: Seconds between polls (default: 30)
+
+    Returns:
+        Dict with status, build_number, duration_ms, and building fields.
+    """
+    terminal_states = {'SUCCESS', 'FAILURE', 'ABORTED', 'UNSTABLE'}
+    start_time = time.time()
+
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed > timeout:
+            return {
+                'status': 'TIMEOUT',
+                'build_number': number,
+                'elapsed_seconds': int(elapsed),
+            }
+
+        build = jenkins(ctx).get_build(fullname=fullname, number=number)
+        build_dict = build.model_dump(exclude_none=True)
+
+        if build_dict.get('result') in terminal_states or not build_dict.get('building', True):
+            return {
+                'status': build_dict.get('result', 'UNKNOWN'),
+                'build_number': build_dict.get('number', number),
+                'duration_ms': build_dict.get('duration', 0),
+                'building': build_dict.get('building', False),
+            }
+
+        await asyncio.sleep(poll_interval)

--- a/src/mcp_jenkins/server/queue.py
+++ b/src/mcp_jenkins/server/queue.py
@@ -1,3 +1,6 @@
+import asyncio
+import time
+
 from fastmcp import Context
 
 from mcp_jenkins.core.lifespan import jenkins
@@ -36,3 +39,48 @@ async def cancel_queue_item(ctx: Context, id: int) -> None:
         id: The id of the queue item
     """
     jenkins(ctx).cancel_queue_item(id=id)
+
+
+@mcp.tool(tags=['read'])
+async def get_queue_to_build(
+    ctx: Context,
+    queue_item_id: int,
+    timeout: int = 600,
+    poll_interval: int = 5,
+) -> dict:
+    """Poll the Jenkins queue until a build is assigned to the queue item.
+
+    Server-side polling — agent calls once, gets result when build is assigned or timeout.
+
+    Args:
+        queue_item_id: The queue item ID returned by build_item()
+        timeout: Max seconds to wait (default: 600)
+        poll_interval: Seconds between polls (default: 5)
+
+    Returns:
+        Dict with status and build_number if completed, or TIMED_OUT with elapsed_seconds.
+    """
+    start_time = time.time()
+
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed > timeout:
+            return {
+                'status': 'TIMED_OUT',
+                'queue_item_id': queue_item_id,
+                'elapsed_seconds': int(elapsed),
+            }
+
+        queue_item = jenkins(ctx).get_queue_item_raw(id=queue_item_id)
+
+        build_info = queue_item.get('build')
+        if build_info:
+            build_number = build_info.get('number')
+            return {
+                'status': 'COMPLETED',
+                'build_number': build_number,
+                'queue_item_id': queue_item_id,
+                'elapsed_seconds': int(elapsed),
+            }
+
+        await asyncio.sleep(poll_interval)


### PR DESCRIPTION

## Overview
This pull request enhances the **mcp-jenkins** server capabilities by introducing three new core tools designed to improve real-time build monitoring, build lifecycle tracking, and queue management.

## New Features & Tools
* **`get_build_console_tail`**: Fetches the latest trailing lines of a specific Jenkins build console log. This allows clients to stream or inspect active logs without requesting the entire history.
* **`wait_for_build_completion`**: Implements polling or waiting mechanics to block or notify the caller until a targeted Jenkins job execution completes.
* **`get_queue_to_build`**: Maps or retrieves the correlation between a queued item ID and its eventual concrete build number once it transitions out of the Jenkins build queue.

## Technical Changes
* Added 2 distinct commits to synchronize the branch and introduce the features.
