### PR TITLE
feat: support Jenkins credentials via environment variables and .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ uvx mcp-jenkins --transport streamable-http
 
 | Argument                                                     | Description                                                                                                     | Required |
 |--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|----------|
+| `--env-file`                                                 | Path to a `.env` file to load configuration from. See [Environment Variables / .env file](#environment-variables--env-file) below. | No       |
 | `--jenkins-url`                                              | The URL of the Jenkins server. (Http app can set it via headers `x-jenkins-url`)                                | No       |
 | `--jenkins-username`                                         | The username for Jenkins authentication. (Http app can set it via headers `x-jenkins-username`)                 | No       |
 | `--jenkins-password`                                         | The password or API token for Jenkins authentication. (Http app can set it via headers `x-jenkins-password`)    | No       |
@@ -43,6 +44,30 @@ uvx mcp-jenkins --transport streamable-http
 | `--transport`                                                | Transport method to use for communication. Options are `stdio`, `sse` or `streamable-http`. Default is `stdio`. | No       |
 | `--host`                                                     | Host address for `streamable-http` transport. Default is `0.0.0.0`                                              | No       |
 | `--port`                                                     | Port number for `streamable-http` transport. Default is `9887`.                                                 | No       |
+
+## Environment Variables / .env file
+
+Instead of passing credentials on the command line, you can set them as environment variables, or put them in a `.env` file:
+
+```
+JENKINS_URL=https://jenkins.example.com
+JENKINS_USERNAME=alice
+JENKINS_PASSWORD=xxxx
+JENKINS_TIMEOUT=5
+JENKINS_VERIFY_SSL=true
+```
+
+If a `.env` file is present in the current directory (or a parent directory), it is loaded automatically — no flag needed:
+```shell
+uvx mcp-jenkins --transport streamable-http
+```
+
+To load a `.env` file from a specific location, use `--env-file`:
+```shell
+uvx mcp-jenkins --env-file /path/to/.env --transport streamable-http
+```
+
+Values already set in the real environment take precedence over the `.env` file, and any `--jenkins-*` CLI flag takes precedence over both.
 
 ## Configuration and Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "beautifulsoup4>=4.14.3",
     "fastmcp>=3.0.2,<4",
     "loguru>=0.7.3",
+    "python-dotenv>=1.0.0",
     "requests>=2.32.5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ lint.fixable = ["ALL"]
 lint.unfixable = []
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 lint.isort.known-third-party = ["pydantic"]
-lint.per-file-ignores."tests/**/*.py" = ["ANN201", "S101", "ANN001", "S106", "ANN202"]
+lint.per-file-ignores."tests/**/*.py" = ["ANN201", "S101", "ANN001", "S105", "S106", "ANN202"]
 
 format.quote-style = "single"
 format.indent-style = "space"

--- a/src/mcp_jenkins/__init__.py
+++ b/src/mcp_jenkins/__init__.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 import click
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from loguru import logger
 
 try:
@@ -19,7 +19,9 @@ if sys.platform == 'win32':
 
 def _load_env_file(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:  # noqa: ARG001
     # Eager so JENKINS_* variables from the file are visible to the other options' envvar lookups below.
-    load_dotenv(dotenv_path=value or None)
+    # find_dotenv(usecwd=True) is used instead of load_dotenv()'s own discovery, which locates the
+    # .env file relative to the caller's source file rather than the current working directory.
+    load_dotenv(dotenv_path=value or find_dotenv(usecwd=True))
     return value
 
 

--- a/src/mcp_jenkins/__init__.py
+++ b/src/mcp_jenkins/__init__.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import click
+from dotenv import load_dotenv
 from loguru import logger
 
 try:
@@ -16,14 +17,31 @@ if sys.platform == 'win32':
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
+def _load_env_file(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:  # noqa: ARG001
+    # Eager so JENKINS_* variables from the file are visible to the other options' envvar lookups below.
+    load_dotenv(dotenv_path=value or None)
+    return value
+
+
 @click.command()
-@click.option('--jenkins-url', required=False)
-@click.option('--jenkins-username', required=False)
-@click.option('--jenkins-password', required=False)
-@click.option('--jenkins-timeout', default=5)
+@click.option(
+    '--env-file',
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    is_eager=True,
+    expose_value=False,
+    callback=_load_env_file,
+    help='Path to a .env file to load configuration from. If omitted, a .env file in the current '
+    'directory (or a parent directory) is loaded automatically if present.',
+)
+@click.option('--jenkins-url', required=False, envvar='JENKINS_URL')
+@click.option('--jenkins-username', required=False, envvar='JENKINS_USERNAME')
+@click.option('--jenkins-password', required=False, envvar='JENKINS_PASSWORD')
+@click.option('--jenkins-timeout', default=5, envvar='JENKINS_TIMEOUT')
 @click.option(
     '--jenkins-verify-ssl/--no-jenkins-verify-ssl',
     default=True,
+    envvar='JENKINS_VERIFY_SSL',
     help='Whether to verify SSL certificates, default is True',
 )
 @click.option(

--- a/tests/test_mcp_jenkins.py
+++ b/tests/test_mcp_jenkins.py
@@ -1,6 +1,17 @@
+import os
+
 from click.testing import CliRunner
 
 from mcp_jenkins import main
+
+JENKINS_ENV_VARS = (
+    'jenkins_url',
+    'jenkins_username',
+    'jenkins_password',
+    'jenkins_timeout',
+    'jenkins_verify_ssl',
+    'jenkins_session_singleton',
+)
 
 
 def test_main_stdio(mocker):
@@ -52,3 +63,92 @@ def test_main(mocker):
     )
 
     mock_mcp.run_async.assert_called_once_with(transport='stdio')
+
+
+def test_main_env_vars(mocker, monkeypatch):
+    mocker.patch('mcp_jenkins.asyncio')
+    mocker.patch('mcp_jenkins.server.mcp')
+
+    for key in JENKINS_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv('JENKINS_URL', 'https://env.example.com')
+    monkeypatch.setenv('JENKINS_USERNAME', 'env-username')
+    monkeypatch.setenv('JENKINS_PASSWORD', 'env-password')
+    monkeypatch.setenv('JENKINS_TIMEOUT', '42')
+    monkeypatch.setenv('JENKINS_VERIFY_SSL', 'false')
+
+    result = CliRunner().invoke(main, ['--transport', 'stdio'])
+
+    assert result.exit_code == 0
+    assert os.environ['jenkins_url'] == 'https://env.example.com'
+    assert os.environ['jenkins_username'] == 'env-username'
+    assert os.environ['jenkins_password'] == 'env-password'
+    assert os.environ['jenkins_timeout'] == '42'
+    assert os.environ['jenkins_verify_ssl'] == 'false'
+
+
+def test_main_cli_arg_overrides_env_var(mocker, monkeypatch):
+    mocker.patch('mcp_jenkins.asyncio')
+    mocker.patch('mcp_jenkins.server.mcp')
+
+    for key in JENKINS_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv('JENKINS_URL', 'https://env.example.com')
+
+    result = CliRunner().invoke(main, ['--transport', 'stdio', '--jenkins-url', 'https://cli.example.com'])
+
+    assert result.exit_code == 0
+    assert os.environ['jenkins_url'] == 'https://cli.example.com'
+
+
+def test_main_env_file_explicit(mocker, monkeypatch, tmp_path):
+    mocker.patch('mcp_jenkins.asyncio')
+    mocker.patch('mcp_jenkins.server.mcp')
+
+    for key in JENKINS_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+    for key in ('JENKINS_URL', 'JENKINS_USERNAME', 'JENKINS_PASSWORD'):
+        monkeypatch.delenv(key, raising=False)
+
+    env_file = tmp_path / 'custom.env'
+    env_file.write_text(
+        'JENKINS_URL=https://file.example.com\nJENKINS_USERNAME=file-username\nJENKINS_PASSWORD=file-password\n'
+    )
+
+    result = CliRunner().invoke(main, ['--env-file', str(env_file), '--transport', 'stdio'])
+
+    assert result.exit_code == 0
+    assert os.environ['jenkins_url'] == 'https://file.example.com'
+    assert os.environ['jenkins_username'] == 'file-username'
+    assert os.environ['jenkins_password'] == 'file-password'
+
+
+def test_main_env_file_missing_path(mocker):
+    mocker.patch('mcp_jenkins.asyncio')
+    mocker.patch('mcp_jenkins.server.mcp')
+
+    result = CliRunner().invoke(main, ['--env-file', 'does-not-exist.env', '--transport', 'stdio'])
+
+    assert result.exit_code != 0
+
+
+def test_main_env_file_autodiscovery(mocker, monkeypatch, tmp_path):
+    mocker.patch('mcp_jenkins.asyncio')
+    mocker.patch('mcp_jenkins.server.mcp')
+
+    for key in JENKINS_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+    for key in ('JENKINS_URL', 'JENKINS_USERNAME', 'JENKINS_PASSWORD'):
+        monkeypatch.delenv(key, raising=False)
+
+    (tmp_path / '.env').write_text(
+        'JENKINS_URL=https://auto.example.com\nJENKINS_USERNAME=auto-username\nJENKINS_PASSWORD=auto-password\n'
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(main, ['--transport', 'stdio'])
+
+    assert result.exit_code == 0
+    assert os.environ['jenkins_url'] == 'https://auto.example.com'
+    assert os.environ['jenkins_username'] == 'auto-username'
+    assert os.environ['jenkins_password'] == 'auto-password'

--- a/uv.lock
+++ b/uv.lock
@@ -839,6 +839,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "fastmcp" },
     { name = "loguru" },
+    { name = "python-dotenv" },
     { name = "requests" },
 ]
 
@@ -856,6 +857,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "fastmcp", specifier = ">=3.0.2,<4" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
 


### PR DESCRIPTION
## Summary

Jenkins credentials could previously only be supplied via CLI flags
(`--jenkins-url`, `--jenkins-username`, `--jenkins-password`), which is
inconvenient for MCP client configs and mildly risky (args are visible in
`ps`, `docker inspect`, and shell history).

This PR adds support for supplying credentials as environment variables or
via an `.env` file, while keeping the existing CLI flags fully working and
unchanged.

## Changes

- `--jenkins-url` / `--jenkins-username` / `--jenkins-password` /
  `--jenkins-timeout` / `--jenkins-verify-ssl` now fall back to the standard
  env vars `JENKINS_URL`, `JENKINS_USERNAME`, `JENKINS_PASSWORD`,
  `JENKINS_TIMEOUT`, `JENKINS_VERIFY_SSL` when the flag isn't passed.
- New `--env-file <path>` option to load a specific `.env` file.
- If `--env-file` is omitted, an `.env` file in the current directory (or a
  parent directory) is discovered and loaded automatically.
- Precedence: CLI flag > real environment variable > `.env` file value.
- Added `python-dotenv` as a direct dependency (it was already present
  transitively via `fastmcp`).
- Documented the new behavior in the README.

## Testing

- Added test coverage for: envvar fallback, CLI-flag-overrides-envvar
  precedence, explicit `--env-file`, a missing `--env-file` path, and `.env`
  auto-discovery in the working directory.
- Full test suite passes (`pytest`), `ruff check` passes.