### PR TITLE
feat: Add pipeline input step tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Note: this is a liveness check only — it does not verify connectivity to the u
 | `get_build_test_report`    | Get the test report of a specific build.            |
 | `get_running_builds`       | Get all currently running builds in Jenkins.        |
 | `stop_build`               | Stop a specific build by job name and build number. |
+| `get_pending_inputs`       | Get the pending input steps of a build paused for input. |
+| `submit_input`             | Proceed with or abort a pipeline input step of a build. |
 | `get_all_build_artifacts`  | List the artifacts of a specific build.             |
 | `get_build_artifact`       | Download an artifact from a specific build.         |
 | `get_build_artifact_url`   | Get the direct URL of an artifact from a specific build. |
@@ -161,6 +163,9 @@ Note: this is a liveness check only — it does not verify connectivity to the u
 | `get_plugin_dependency_graph` | Get dependency graph for a plugin in Graphviz format. |
 | `run_groovy_script`       | Execute an arbitrary Groovy script on Jenkins.     |
 
+Note: `get_pending_inputs` reads the `wfapi` endpoint served by the `pipeline-rest-api` plugin (bundled with
+`pipeline-stage-view`). `submit_input` only needs that plugin when `input_id` is omitted — pass `input_id`
+explicitly and it works on any Jenkins with the `pipeline-input-step` plugin.
 
 ## Contributing
 [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/src/mcp_jenkins/jenkins/__init__.py
+++ b/src/mcp_jenkins/jenkins/__init__.py
@@ -1,3 +1,3 @@
-from .rest_client import Jenkins
+from .rest_client import Jenkins, PendingInputsUnavailableError
 
-__all__ = ['Jenkins']
+__all__ = ['Jenkins', 'PendingInputsUnavailableError']

--- a/src/mcp_jenkins/jenkins/model/build.py
+++ b/src/mcp_jenkins/jenkins/model/build.py
@@ -26,3 +26,16 @@ class Build(BaseModel):
 
 class BuildReplay(BaseModel):
     scripts: list[str]
+
+
+class PendingInput(BaseModel):
+    id: str
+
+    message: str | None = None
+    proceedText: str | None = None
+
+    inputs: list[dict] = []
+
+    proceedUrl: str | None = None
+    abortUrl: str | None = None
+    redirectApprovalUrl: str | None = None

--- a/src/mcp_jenkins/jenkins/model/build.py
+++ b/src/mcp_jenkins/jenkins/model/build.py
@@ -28,6 +28,9 @@ class BuildReplay(BaseModel):
     scripts: list[str]
 
 
+# The wfapi URL fields (proceedUrl, abortUrl, redirectApprovalUrl) are deliberately not modeled: they
+# embed the input id already URL-encoded, and exposing them invites feeding that encoded segment back
+# as input_id, which gets encoded a second time on submission.
 class PendingInput(BaseModel):
     id: str
 
@@ -35,7 +38,3 @@ class PendingInput(BaseModel):
     proceedText: str | None = None
 
     inputs: list[dict] = []
-
-    proceedUrl: str | None = None
-    abortUrl: str | None = None
-    redirectApprovalUrl: str | None = None

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -383,8 +383,7 @@ class Jenkins:
                 msg = (
                     f'No wfapi pending input endpoint for {fullname} #{number}. Either the build does not '
                     f'exist, the job is not a pipeline, or the pipeline-rest-api plugin (bundled with '
-                    f'pipeline-stage-view) is not installed. submit_input can skip this discovery step '
-                    f'entirely when input_id is passed explicitly.'
+                    f'pipeline-stage-view) is not installed.'
                 )
                 raise ValueError(msg) from e
             raise

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -23,6 +23,15 @@ from mcp_jenkins.jenkins.model.node import Node
 from mcp_jenkins.jenkins.model.queue import Queue, QueueItem
 
 
+class PendingInputsUnavailableError(ValueError):
+    """The wfapi pending input endpoint is not available for a build.
+
+    Raised on a 404: the build does not exist, the job is not a pipeline, or the pipeline-rest-api
+    plugin is missing. Kept distinct from other ValueErrors (malformed responses, validation failures)
+    so callers can degrade gracefully only when the endpoint itself is absent.
+    """
+
+
 class Jenkins:
     DEFAULT_HEADERS = {'Content-Type': 'text/xml; charset=utf-8'}
 
@@ -368,7 +377,7 @@ class Jenkins:
             A list of PendingInput objects, empty when the build is not waiting for input.
 
         Raises:
-            ValueError: If the wfapi pending input endpoint is not available.
+            PendingInputsUnavailableError: If the wfapi pending input endpoint is not available.
         """
         folder, name = self._parse_fullname(fullname)
 
@@ -385,7 +394,7 @@ class Jenkins:
                     f'exist, the job is not a pipeline, or the pipeline-rest-api plugin (bundled with '
                     f'pipeline-stage-view) is not installed.'
                 )
-                raise ValueError(msg) from e
+                raise PendingInputsUnavailableError(msg) from e
             raise
 
         return [PendingInput.model_validate(pending_input) for pending_input in response.json()]
@@ -612,12 +621,21 @@ class Jenkins:
             fullname: The full name of the item (e.g., "folder1/folder2/item").
 
         Returns:
-            The last build number, or None when the item has never been built or cannot have builds.
+            The last build number, or None when the job has never been built.
+
+        Raises:
+            ValueError: If the item cannot have builds at all (e.g. a folder or multibranch parent).
         """
         folder, name = self._parse_fullname(fullname)
         response = self.request('GET', rest_endpoint.ITEM_LAST_BUILD_NUMBER(folder=folder, name=name))
 
-        return (response.json().get('lastBuild') or {}).get('number')
+        data = response.json()
+        # Only Job subtypes expose `buildable`; its absence means the item is a folder-like container
+        # that can never have builds, as opposed to a job that simply has none yet.
+        if 'buildable' not in data:
+            raise ValueError(f'{fullname} cannot have builds (a folder or multibranch parent?), pass a job fullname')
+
+        return (data.get('lastBuild') or {}).get('number')
 
     def get_item_config(self, *, fullname: str) -> str:
         """Get item configuration by its fullname.

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -378,11 +378,13 @@ class Jenkins:
                 rest_endpoint.BUILD_PENDING_INPUTS(folder=folder, name=name, number=number),
             )
         except HTTPError as e:
-            if e.response.status_code == 404:
+            # A transport-level HTTPError carries no response, so the status can only be read defensively.
+            if e.response is not None and e.response.status_code == 404:
                 msg = (
                     f'No wfapi pending input endpoint for {fullname} #{number}. Either the build does not '
                     f'exist, the job is not a pipeline, or the pipeline-rest-api plugin (bundled with '
-                    f'pipeline-stage-view) is not installed. Pass input_id explicitly to skip discovery.'
+                    f'pipeline-stage-view) is not installed. submit_input can skip this discovery step '
+                    f'entirely when input_id is passed explicitly.'
                 )
                 raise ValueError(msg) from e
             raise
@@ -603,6 +605,20 @@ class Jenkins:
         folder, name = self._parse_fullname(fullname)
         response = self.request('GET', rest_endpoint.ITEM(folder=folder, name=name, depth=depth))
         return serialize_item(response.json())
+
+    def get_last_build_number(self, *, fullname: str) -> int | None:
+        """Get the number of the last build of an item.
+
+        Args:
+            fullname: The full name of the item (e.g., "folder1/folder2/item").
+
+        Returns:
+            The last build number, or None when the item has never been built or cannot have builds.
+        """
+        folder, name = self._parse_fullname(fullname)
+        response = self.request('GET', rest_endpoint.ITEM_LAST_BUILD_NUMBER(folder=folder, name=name))
+
+        return (response.json().get('lastBuild') or {}).get('number')
 
     def get_item_config(self, *, fullname: str) -> str:
         """Get item configuration by its fullname.

--- a/src/mcp_jenkins/jenkins/rest_client.py
+++ b/src/mcp_jenkins/jenkins/rest_client.py
@@ -1,6 +1,8 @@
+import json
 import re
 from functools import reduce
 from typing import Literal
+from urllib.parse import quote
 
 import requests
 from bs4 import BeautifulSoup
@@ -10,7 +12,7 @@ from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 
 from mcp_jenkins.jenkins import rest_endpoint
-from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay
+from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay, PendingInput
 from mcp_jenkins.jenkins.model.item import (
     FreeStyleProject,
     ItemType,
@@ -162,8 +164,6 @@ class Jenkins:
         Returns:
             The Jenkins URL path segment (e.g. "view/frontend/view/nightly").
         """
-        from urllib.parse import quote
-
         parts = [quote(p.strip(), safe='') for p in view_path.split('/') if p.strip()]
         return '/'.join(f'view/{p}' for p in parts)
 
@@ -352,6 +352,81 @@ class Jenkins:
         """
         folder, name = self._parse_fullname(fullname)
         self.request('POST', rest_endpoint.BUILD_STOP(folder=folder, name=name, number=number))
+
+    def get_build_pending_inputs(self, *, fullname: str, number: int) -> list[PendingInput]:
+        """Get the pending input steps of a specific build.
+
+        A pipeline that is "Paused for Input" is waiting on an input step. Requires the
+        pipeline-rest-api plugin, which is bundled with pipeline-stage-view and serves the wfapi
+        endpoints.
+
+        Args:
+            fullname: The fullname of the job.
+            number: The build number.
+
+        Returns:
+            A list of PendingInput objects, empty when the build is not waiting for input.
+
+        Raises:
+            ValueError: If the wfapi pending input endpoint is not available.
+        """
+        folder, name = self._parse_fullname(fullname)
+
+        try:
+            response = self.request(
+                'GET',
+                rest_endpoint.BUILD_PENDING_INPUTS(folder=folder, name=name, number=number),
+            )
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                msg = (
+                    f'No wfapi pending input endpoint for {fullname} #{number}. Either the build does not '
+                    f'exist, the job is not a pipeline, or the pipeline-rest-api plugin (bundled with '
+                    f'pipeline-stage-view) is not installed. Pass input_id explicitly to skip discovery.'
+                )
+                raise ValueError(msg) from e
+            raise
+
+        return [PendingInput.model_validate(pending_input) for pending_input in response.json()]
+
+    def submit_build_input(
+        self,
+        *,
+        fullname: str,
+        number: int,
+        input_id: str,
+        action: Literal['proceed', 'proceedEmpty', 'abort'] = 'proceed',
+        parameters: dict | None = None,
+    ) -> None:
+        """Settle a pending input step of a specific build.
+
+        Args:
+            fullname: The fullname of the job.
+            number: The build number.
+            input_id: The id of the pending input step.
+            action: 'proceed' submits parameters, 'proceedEmpty' proceeds without any, 'abort' aborts the build.
+            parameters: A mapping of parameter name to value, only used when action is 'proceed'.
+        """
+        folder, name = self._parse_fullname(fullname)
+
+        # Stapler reads the submitted form from the `json` field, so it must be present even when the
+        # input step declares no parameters. `proceedEmpty` and `abort` take no body at all.
+        data = None
+        if action == 'proceed':
+            values = [{'name': key, 'value': value} for key, value in (parameters or {}).items()]
+            data = {'json': json.dumps({'parameter': values})}
+
+        self.request(
+            'POST',
+            rest_endpoint.BUILD_INPUT(
+                folder=folder,
+                name=name,
+                number=number,
+                input_id=quote(input_id, safe=''),
+                action=action,
+            ),
+            data=data,
+        )
 
     def get_build_replay(self, *, fullname: str, number: int) -> BuildReplay:
         """Get the build replay of a specific build.

--- a/src/mcp_jenkins/jenkins/rest_endpoint.py
+++ b/src/mcp_jenkins/jenkins/rest_endpoint.py
@@ -40,6 +40,8 @@ BUILD_PARAMETERS = RestEndpoint('{folder}job/{name}/{number}/api/json?tree=actio
 BUILD_TEST_REPORT = RestEndpoint('{folder}job/{name}/{number}/testReport/api/json?depth={depth}')
 BUILD_ARTIFACT = RestEndpoint('{folder}job/{name}/{number}/artifact/{relative_path}')
 BUILD_ARTIFACTS = RestEndpoint('{folder}job/{name}/{number}/api/json?tree=artifacts[fileName,relativePath,displayPath]')
+BUILD_PENDING_INPUTS = RestEndpoint('{folder}job/{name}/{number}/wfapi/pendingInputActions')
+BUILD_INPUT = RestEndpoint('{folder}job/{name}/{number}/input/{input_id}/{action}')
 
 PLUGIN_LIST = RestEndpoint('pluginManager/api/json?depth={depth}')
 PLUGIN_LIST_TREE = RestEndpoint('pluginManager/api/json?tree=plugins[{tree}]')

--- a/src/mcp_jenkins/jenkins/rest_endpoint.py
+++ b/src/mcp_jenkins/jenkins/rest_endpoint.py
@@ -17,7 +17,7 @@ class RestEndpoint(str):
 CRUMB = RestEndpoint('crumbIssuer/api/json')
 
 ITEM = RestEndpoint('{folder}job/{name}/api/json?depth={depth}')
-ITEM_LAST_BUILD_NUMBER = RestEndpoint('{folder}job/{name}/api/json?tree=lastBuild[number]')
+ITEM_LAST_BUILD_NUMBER = RestEndpoint('{folder}job/{name}/api/json?tree=lastBuild[number],buildable')
 ITEMS = RestEndpoint('{folder}/api/json?tree={query}')
 ITEM_CONFIG = RestEndpoint('{folder}job/{name}/config.xml')
 ITEM_BUILD = RestEndpoint('{folder}job/{name}/{build_type}')

--- a/src/mcp_jenkins/jenkins/rest_endpoint.py
+++ b/src/mcp_jenkins/jenkins/rest_endpoint.py
@@ -17,6 +17,7 @@ class RestEndpoint(str):
 CRUMB = RestEndpoint('crumbIssuer/api/json')
 
 ITEM = RestEndpoint('{folder}job/{name}/api/json?depth={depth}')
+ITEM_LAST_BUILD_NUMBER = RestEndpoint('{folder}job/{name}/api/json?tree=lastBuild[number]')
 ITEMS = RestEndpoint('{folder}/api/json?tree={query}')
 ITEM_CONFIG = RestEndpoint('{folder}job/{name}/config.xml')
 ITEM_BUILD = RestEndpoint('{folder}job/{name}/{build_type}')

--- a/src/mcp_jenkins/server/build.py
+++ b/src/mcp_jenkins/server/build.py
@@ -2,18 +2,22 @@ import base64
 from typing import Literal
 
 from fastmcp import Context
+from requests.exceptions import HTTPError
 
 from mcp_jenkins.core.lifespan import jenkins
-from mcp_jenkins.jenkins import Jenkins
+from mcp_jenkins.jenkins import Jenkins, PendingInputsUnavailableError
 from mcp_jenkins.server import mcp
 
 
-def _last_build_number(client: Jenkins, fullname: str) -> int:
-    """Resolve the last build number of a job, raising a clear error when it has none
+def _resolve_build_number(client: Jenkins, fullname: str, number: int | None) -> int:
+    """Resolve an omitted build number to the job's last build, raising a clear error when it has none
 
     The number is fetched with a tree query rather than a depth=1 item fetch: the latter returns every
     build stub, action and parameter definition of the job to read a single integer.
     """
+    if number is not None:
+        return number
+
     number = client.get_last_build_number(fullname=fullname)
     if number is None:
         raise ValueError(f'No build found for job: {fullname}')
@@ -45,8 +49,7 @@ async def get_build(ctx: Context, fullname: str, number: int | None = None) -> d
     Returns:
         The build info
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     return jenkins(ctx).get_build(fullname=fullname, number=number).model_dump(exclude_none=True)
 
@@ -62,8 +65,7 @@ async def get_build_scripts(ctx: Context, fullname: str, number: int | None = No
     Returns:
         A list of scripts used in the build
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     return jenkins(ctx).get_build_replay(fullname=fullname, number=number).scripts
 
@@ -89,8 +91,7 @@ async def get_build_console_output(
     Returns:
         The console output of the build
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     return jenkins(ctx).get_build_console_output(
         fullname=fullname, number=number, pattern=pattern, offset=offset, limit=limit
@@ -108,8 +109,7 @@ async def get_build_test_report(ctx: Context, fullname: str, number: int | None 
     Returns:
         The test report of the build
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     return jenkins(ctx).get_build_test_report(fullname=fullname, number=number)
 
@@ -125,8 +125,7 @@ async def get_build_parameters(ctx: Context, fullname: str, number: int | None =
     Returns:
         A dictionary of build parameter names and their values
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     return jenkins(ctx).get_build_parameters(fullname=fullname, number=number)
 
@@ -149,22 +148,23 @@ async def get_pending_inputs(ctx: Context, fullname: str, number: int | None = N
     A pipeline showing "Paused for Input" is waiting on an input step. Call this before submit_input
     to discover the input id and the parameter definitions the pipeline is waiting for.
 
+    Only the given build is inspected. With number=None that is the job's last build, so a paused build
+    that is no longer the most recent one is not found that way — locate it with get_running_builds and
+    pass its number explicitly.
+
     Args:
         fullname: The fullname of the job
-        number: The number of the build, if None, get the last build
+        number: The number of the build, if None, check the last build
 
     Returns:
         A list of pending inputs with id, message, proceedText and inputs (parameter definitions)
     """
     client = jenkins(ctx)
 
-    if number is None:
-        number = _last_build_number(client, fullname)
+    number = _resolve_build_number(client, fullname, number)
 
-    # The wfapi URLs embed the input id already URL-encoded; exposing them invites feeding that encoded
-    # segment back as input_id, which gets encoded a second time on submission.
     return [
-        pending_input.model_dump(exclude_none=True, exclude={'proceedUrl', 'abortUrl', 'redirectApprovalUrl'})
+        pending_input.model_dump(exclude_none=True)
         for pending_input in client.get_build_pending_inputs(fullname=fullname, number=number)
     ]
 
@@ -183,14 +183,16 @@ async def submit_input(
     Warnings:
         Omitting a declared parameter settles it with null — Jenkins does not fall back to the declared
         defaults, so every declared parameter must be submitted. That is enforced whenever the pending
-        input can be discovered; when the wfapi endpoint is unavailable an explicit input_id is submitted
-        as-is, so check the declared parameters yourself in that case.
+        input can be discovered; when the pending inputs cannot be fetched (wfapi endpoint missing or
+        erroring) an explicit input_id is submitted as-is, so check the declared parameters yourself in
+        that case.
         If this call times out the input may or may not have been settled: re-check with
         get_pending_inputs rather than retrying, because a settled input rejects a second submission.
 
     Args:
         fullname: The fullname of the job
-        number: The number of the build to respond to, use get_pending_inputs to find the paused build
+        number: The number of the paused build, use get_pending_inputs to confirm its pending input
+            (and get_running_builds to locate a paused build that is not the job's last one)
         input_id: The id of the pending input, if None, resolved automatically when exactly one is pending
         parameters: A mapping of parameter name to value, e.g. {'APPROVE': True, 'TARGET': 'prod'}
         action: 'proceed' to continue the pipeline, 'abort' to reject the input and abort the build
@@ -205,10 +207,21 @@ async def submit_input(
     client = jenkins(ctx)
 
     # Validation needs the pending input's declared parameters. An explicit input_id must stay usable on
-    # controllers without the wfapi endpoint, so there a failed discovery degrades to no validation.
+    # controllers where the wfapi endpoint is missing or unreadable, so there a failed discovery degrades
+    # to no validation. Malformed wfapi responses are not a degrade signal — they raise, because silently
+    # skipping validation lets a misspelled parameter settle the real one with null.
+    pending_inputs = None
+    discovery_error = None
+    if input_id is None or action == 'proceed':
+        try:
+            pending_inputs = client.get_build_pending_inputs(fullname=fullname, number=number)
+        except (PendingInputsUnavailableError, HTTPError) as e:
+            if input_id is None:
+                raise
+            discovery_error = e
+
     pending = None
     if input_id is None:
-        pending_inputs = client.get_build_pending_inputs(fullname=fullname, number=number)
         if not pending_inputs:
             raise ValueError(f'No pending input for {fullname} #{number}')
         if len(pending_inputs) > 1:
@@ -216,16 +229,11 @@ async def submit_input(
             raise ValueError(f'Multiple pending inputs for {fullname} #{number}, pass input_id: {ids}')
         pending = pending_inputs[0]
         input_id = pending.id
-    elif action == 'proceed':
-        try:
-            pending_inputs = client.get_build_pending_inputs(fullname=fullname, number=number)
-        except ValueError:
-            pending_inputs = None
-        if pending_inputs is not None:
-            pending = next((pending_input for pending_input in pending_inputs if pending_input.id == input_id), None)
-            if pending is None:
-                ids = ', '.join(pending_input.id for pending_input in pending_inputs) or 'none'
-                raise ValueError(f'No pending input {input_id} for {fullname} #{number}. Pending inputs: {ids}')
+    elif pending_inputs is not None:
+        pending = next((pending_input for pending_input in pending_inputs if pending_input.id == input_id), None)
+        if pending is None:
+            ids = ', '.join(pending_input.id for pending_input in pending_inputs) or 'none'
+            raise ValueError(f'No pending input {input_id} for {fullname} #{number}. Pending inputs: {ids}')
 
     if pending is not None and action == 'proceed':
         declared = {parameter['name'] for parameter in pending.inputs if 'name' in parameter}
@@ -253,9 +261,22 @@ async def submit_input(
     else:
         jenkins_action = 'proceed' if parameters else 'proceedEmpty'
 
-    client.submit_build_input(
-        fullname=fullname, number=number, input_id=input_id, action=jenkins_action, parameters=parameters
-    )
+    try:
+        client.submit_build_input(
+            fullname=fullname, number=number, input_id=input_id, action=jenkins_action, parameters=parameters
+        )
+    except HTTPError as e:
+        if discovery_error is not None:
+            msg = (
+                f'Submitting input {input_id} for {fullname} #{number} failed ({e}) and the pending inputs '
+                f'could not be checked beforehand: {discovery_error}'
+            )
+        else:
+            msg = (
+                f'Submitting input {input_id} for {fullname} #{number} failed ({e}). The input may already '
+                f'be settled — re-check with get_pending_inputs rather than retrying.'
+            )
+        raise ValueError(msg) from e
 
     return {'fullname': fullname, 'number': number, 'inputId': input_id, 'action': jenkins_action}
 
@@ -271,8 +292,7 @@ async def get_all_build_artifacts(ctx: Context, fullname: str, number: int | Non
     Returns:
         A list of artifact metadata dicts with fileName, relativePath, and displayPath
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     return [
         artifact.model_dump(exclude_none=True)
@@ -294,8 +314,7 @@ async def get_build_artifact(ctx: Context, fullname: str, relative_path: str, nu
     Returns:
         A dict with 'content' (str) and 'encoding' ('utf-8' or 'base64')
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     content = jenkins(ctx).get_build_artifact(fullname=fullname, number=number, relative_path=relative_path)
 
@@ -317,7 +336,6 @@ async def get_build_artifact_url(ctx: Context, fullname: str, relative_path: str
     Returns:
         The direct Jenkins URL of the artifact
     """
-    if number is None:
-        number = _last_build_number(jenkins(ctx), fullname)
+    number = _resolve_build_number(jenkins(ctx), fullname, number)
 
     return jenkins(ctx).get_build_artifact_url(fullname=fullname, number=number, relative_path=relative_path)

--- a/src/mcp_jenkins/server/build.py
+++ b/src/mcp_jenkins/server/build.py
@@ -46,7 +46,7 @@ async def get_build(ctx: Context, fullname: str, number: int | None = None) -> d
         The build info
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
+        number = _last_build_number(jenkins(ctx), fullname)
 
     return jenkins(ctx).get_build(fullname=fullname, number=number).model_dump(exclude_none=True)
 
@@ -63,7 +63,7 @@ async def get_build_scripts(ctx: Context, fullname: str, number: int | None = No
         A list of scripts used in the build
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
+        number = _last_build_number(jenkins(ctx), fullname)
 
     return jenkins(ctx).get_build_replay(fullname=fullname, number=number).scripts
 
@@ -90,9 +90,7 @@ async def get_build_console_output(
         The console output of the build
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
-    if number is None:
-        raise ValueError(f'No build found for job: {fullname}')
+        number = _last_build_number(jenkins(ctx), fullname)
 
     return jenkins(ctx).get_build_console_output(
         fullname=fullname, number=number, pattern=pattern, offset=offset, limit=limit
@@ -111,7 +109,7 @@ async def get_build_test_report(ctx: Context, fullname: str, number: int | None 
         The test report of the build
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
+        number = _last_build_number(jenkins(ctx), fullname)
 
     return jenkins(ctx).get_build_test_report(fullname=fullname, number=number)
 
@@ -128,7 +126,7 @@ async def get_build_parameters(ctx: Context, fullname: str, number: int | None =
         A dictionary of build parameter names and their values
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
+        number = _last_build_number(jenkins(ctx), fullname)
 
     return jenkins(ctx).get_build_parameters(fullname=fullname, number=number)
 
@@ -163,8 +161,10 @@ async def get_pending_inputs(ctx: Context, fullname: str, number: int | None = N
     if number is None:
         number = _last_build_number(client, fullname)
 
+    # The wfapi URLs embed the input id already URL-encoded; exposing them invites feeding that encoded
+    # segment back as input_id, which gets encoded a second time on submission.
     return [
-        pending_input.model_dump(exclude_none=True)
+        pending_input.model_dump(exclude_none=True, exclude={'proceedUrl', 'abortUrl', 'redirectApprovalUrl'})
         for pending_input in client.get_build_pending_inputs(fullname=fullname, number=number)
     ]
 
@@ -181,9 +181,10 @@ async def submit_input(
     """Respond to a pipeline input step of a build that is paused for input in Jenkins
 
     Warnings:
-        Omitting parameters proceeds without submitting any values — Jenkins does not fall back to the
-        declared defaults. That is refused when the input is discovered here, but passing input_id skips
-        discovery, so call get_pending_inputs first in that case.
+        Omitting a declared parameter settles it with null — Jenkins does not fall back to the declared
+        defaults, so every declared parameter must be submitted. That is enforced whenever the pending
+        input can be discovered; when the wfapi endpoint is unavailable an explicit input_id is submitted
+        as-is, so check the declared parameters yourself in that case.
         If this call times out the input may or may not have been settled: re-check with
         get_pending_inputs rather than retrying, because a settled input rejects a second submission.
 
@@ -203,9 +204,9 @@ async def submit_input(
 
     client = jenkins(ctx)
 
-    # Only known when the input is discovered here: an explicit input_id skips the wfapi lookup.
-    declared = None
-
+    # Validation needs the pending input's declared parameters. An explicit input_id must stay usable on
+    # controllers without the wfapi endpoint, so there a failed discovery degrades to no validation.
+    pending = None
     if input_id is None:
         pending_inputs = client.get_build_pending_inputs(fullname=fullname, number=number)
         if not pending_inputs:
@@ -213,24 +214,37 @@ async def submit_input(
         if len(pending_inputs) > 1:
             ids = ', '.join(pending_input.id for pending_input in pending_inputs)
             raise ValueError(f'Multiple pending inputs for {fullname} #{number}, pass input_id: {ids}')
-        input_id = pending_inputs[0].id
-        declared = {parameter['name'] for parameter in pending_inputs[0].inputs if 'name' in parameter}
+        pending = pending_inputs[0]
+        input_id = pending.id
+    elif action == 'proceed':
+        try:
+            pending_inputs = client.get_build_pending_inputs(fullname=fullname, number=number)
+        except ValueError:
+            pending_inputs = None
+        if pending_inputs is not None:
+            pending = next((pending_input for pending_input in pending_inputs if pending_input.id == input_id), None)
+            if pending is None:
+                ids = ', '.join(pending_input.id for pending_input in pending_inputs) or 'none'
+                raise ValueError(f'No pending input {input_id} for {fullname} #{number}. Pending inputs: {ids}')
 
-    # An input that reports no definitions is left to Jenkins: absent data is not proof of absent parameters.
-    if declared and action == 'proceed':
-        if not parameters:
-            msg = (
-                f'Input {input_id} of {fullname} #{number} declares {", ".join(sorted(declared))}. '
-                f'Proceeding without values settles it with null rather than the declared defaults, '
-                f'so pass parameters explicitly.'
-            )
-            raise ValueError(msg)
+    if pending is not None and action == 'proceed':
+        declared = {parameter['name'] for parameter in pending.inputs if 'name' in parameter}
+        submitted = set(parameters or {})
 
-        unknown = sorted(set(parameters) - declared)
+        unknown = sorted(submitted - declared)
         if unknown:
             msg = (
                 f'Input {input_id} of {fullname} #{number} does not declare {", ".join(unknown)}. '
-                f'Declared parameters: {", ".join(sorted(declared))}'
+                f'Declared parameters: {", ".join(sorted(declared)) or "none"}'
+            )
+            raise ValueError(msg)
+
+        missing = sorted(declared - submitted)
+        if missing:
+            msg = (
+                f'Input {input_id} of {fullname} #{number} declares {", ".join(sorted(declared))} but got '
+                f'no value for {", ".join(missing)}. Omitted parameters settle with null rather than their '
+                f'declared defaults, so pass every declared parameter.'
             )
             raise ValueError(msg)
 
@@ -258,7 +272,7 @@ async def get_all_build_artifacts(ctx: Context, fullname: str, number: int | Non
         A list of artifact metadata dicts with fileName, relativePath, and displayPath
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
+        number = _last_build_number(jenkins(ctx), fullname)
 
     return [
         artifact.model_dump(exclude_none=True)
@@ -281,7 +295,7 @@ async def get_build_artifact(ctx: Context, fullname: str, relative_path: str, nu
         A dict with 'content' (str) and 'encoding' ('utf-8' or 'base64')
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
+        number = _last_build_number(jenkins(ctx), fullname)
 
     content = jenkins(ctx).get_build_artifact(fullname=fullname, number=number, relative_path=relative_path)
 
@@ -304,6 +318,6 @@ async def get_build_artifact_url(ctx: Context, fullname: str, relative_path: str
         The direct Jenkins URL of the artifact
     """
     if number is None:
-        number = jenkins(ctx).get_item(fullname=fullname, depth=1).lastBuild.number
+        number = _last_build_number(jenkins(ctx), fullname)
 
     return jenkins(ctx).get_build_artifact_url(fullname=fullname, number=number, relative_path=relative_path)

--- a/src/mcp_jenkins/server/build.py
+++ b/src/mcp_jenkins/server/build.py
@@ -4,20 +4,21 @@ from typing import Literal
 from fastmcp import Context
 
 from mcp_jenkins.core.lifespan import jenkins
+from mcp_jenkins.jenkins import Jenkins
 from mcp_jenkins.server import mcp
 
 
-def _last_build_number(ctx: Context, fullname: str) -> int:
+def _last_build_number(client: Jenkins, fullname: str) -> int:
     """Resolve the last build number of a job, raising a clear error when it has none
 
-    Items that have never been built carry lastBuild=None, and item types such as Folder have no
-    lastBuild field at all, so the attribute is read defensively rather than dereferenced directly.
+    The number is fetched with a tree query rather than a depth=1 item fetch: the latter returns every
+    build stub, action and parameter definition of the job to read a single integer.
     """
-    last_build = getattr(jenkins(ctx).get_item(fullname=fullname, depth=1), 'lastBuild', None)
-    if last_build is None:
+    number = client.get_last_build_number(fullname=fullname)
+    if number is None:
         raise ValueError(f'No build found for job: {fullname}')
 
-    return last_build.number
+    return number
 
 
 @mcp.tool(tags=['read'])
@@ -157,12 +158,14 @@ async def get_pending_inputs(ctx: Context, fullname: str, number: int | None = N
     Returns:
         A list of pending inputs with id, message, proceedText and inputs (parameter definitions)
     """
+    client = jenkins(ctx)
+
     if number is None:
-        number = _last_build_number(ctx, fullname)
+        number = _last_build_number(client, fullname)
 
     return [
         pending_input.model_dump(exclude_none=True)
-        for pending_input in jenkins(ctx).get_build_pending_inputs(fullname=fullname, number=number)
+        for pending_input in client.get_build_pending_inputs(fullname=fullname, number=number)
     ]
 
 
@@ -170,7 +173,7 @@ async def get_pending_inputs(ctx: Context, fullname: str, number: int | None = N
 async def submit_input(
     ctx: Context,
     fullname: str,
-    number: int | None = None,
+    number: int,
     input_id: str | None = None,
     parameters: dict | None = None,
     action: Literal['proceed', 'abort'] = 'proceed',
@@ -179,45 +182,68 @@ async def submit_input(
 
     Warnings:
         Omitting parameters proceeds without submitting any values — Jenkins does not fall back to the
-        declared defaults. Call get_pending_inputs first when the input declares parameters.
+        declared defaults. That is refused when the input is discovered here, but passing input_id skips
+        discovery, so call get_pending_inputs first in that case.
         If this call times out the input may or may not have been settled: re-check with
         get_pending_inputs rather than retrying, because a settled input rejects a second submission.
 
     Args:
         fullname: The fullname of the job
-        number: The number of the build, if None, use the last build
+        number: The number of the build to respond to, use get_pending_inputs to find the paused build
         input_id: The id of the pending input, if None, resolved automatically when exactly one is pending
         parameters: A mapping of parameter name to value, e.g. {'APPROVE': True, 'TARGET': 'prod'}
         action: 'proceed' to continue the pipeline, 'abort' to reject the input and abort the build
 
     Returns:
-        A dict with the fullname, number, inputId and action that were submitted
+        A dict with the fullname, number, inputId and the Jenkins action that was submitted:
+        'proceed' with values, 'proceedEmpty' with none, or 'abort'
     """
-    if number is None:
-        number = _last_build_number(ctx, fullname)
-
     if action == 'abort' and parameters:
         raise ValueError(f'parameters cannot be combined with action="abort" for {fullname} #{number}')
 
+    client = jenkins(ctx)
+
+    # Only known when the input is discovered here: an explicit input_id skips the wfapi lookup.
+    declared = None
+
     if input_id is None:
-        pending_inputs = jenkins(ctx).get_build_pending_inputs(fullname=fullname, number=number)
+        pending_inputs = client.get_build_pending_inputs(fullname=fullname, number=number)
         if not pending_inputs:
             raise ValueError(f'No pending input for {fullname} #{number}')
         if len(pending_inputs) > 1:
             ids = ', '.join(pending_input.id for pending_input in pending_inputs)
             raise ValueError(f'Multiple pending inputs for {fullname} #{number}, pass input_id: {ids}')
         input_id = pending_inputs[0].id
+        declared = {parameter['name'] for parameter in pending_inputs[0].inputs if 'name' in parameter}
+
+    # An input that reports no definitions is left to Jenkins: absent data is not proof of absent parameters.
+    if declared and action == 'proceed':
+        if not parameters:
+            msg = (
+                f'Input {input_id} of {fullname} #{number} declares {", ".join(sorted(declared))}. '
+                f'Proceeding without values settles it with null rather than the declared defaults, '
+                f'so pass parameters explicitly.'
+            )
+            raise ValueError(msg)
+
+        unknown = sorted(set(parameters) - declared)
+        if unknown:
+            msg = (
+                f'Input {input_id} of {fullname} #{number} does not declare {", ".join(unknown)}. '
+                f'Declared parameters: {", ".join(sorted(declared))}'
+            )
+            raise ValueError(msg)
 
     if action == 'abort':
         jenkins_action = 'abort'
     else:
         jenkins_action = 'proceed' if parameters else 'proceedEmpty'
 
-    jenkins(ctx).submit_build_input(
+    client.submit_build_input(
         fullname=fullname, number=number, input_id=input_id, action=jenkins_action, parameters=parameters
     )
 
-    return {'fullname': fullname, 'number': number, 'inputId': input_id, 'action': action}
+    return {'fullname': fullname, 'number': number, 'inputId': input_id, 'action': jenkins_action}
 
 
 @mcp.tool(tags=['read'])

--- a/src/mcp_jenkins/server/build.py
+++ b/src/mcp_jenkins/server/build.py
@@ -1,9 +1,23 @@
 import base64
+from typing import Literal
 
 from fastmcp import Context
 
 from mcp_jenkins.core.lifespan import jenkins
 from mcp_jenkins.server import mcp
+
+
+def _last_build_number(ctx: Context, fullname: str) -> int:
+    """Resolve the last build number of a job, raising a clear error when it has none
+
+    Items that have never been built carry lastBuild=None, and item types such as Folder have no
+    lastBuild field at all, so the attribute is read defensively rather than dereferenced directly.
+    """
+    last_build = getattr(jenkins(ctx).get_item(fullname=fullname, depth=1), 'lastBuild', None)
+    if last_build is None:
+        raise ValueError(f'No build found for job: {fullname}')
+
+    return last_build.number
 
 
 @mcp.tool(tags=['read'])
@@ -127,6 +141,83 @@ async def stop_build(ctx: Context, fullname: str, number: int) -> None:
         number: The number of the build to stop
     """
     return jenkins(ctx).stop_build(fullname=fullname, number=number)
+
+
+@mcp.tool(tags=['read'])
+async def get_pending_inputs(ctx: Context, fullname: str, number: int | None = None) -> list[dict]:
+    """Get the pending input steps of a specific build in Jenkins
+
+    A pipeline showing "Paused for Input" is waiting on an input step. Call this before submit_input
+    to discover the input id and the parameter definitions the pipeline is waiting for.
+
+    Args:
+        fullname: The fullname of the job
+        number: The number of the build, if None, get the last build
+
+    Returns:
+        A list of pending inputs with id, message, proceedText and inputs (parameter definitions)
+    """
+    if number is None:
+        number = _last_build_number(ctx, fullname)
+
+    return [
+        pending_input.model_dump(exclude_none=True)
+        for pending_input in jenkins(ctx).get_build_pending_inputs(fullname=fullname, number=number)
+    ]
+
+
+@mcp.tool(tags=['write'])
+async def submit_input(
+    ctx: Context,
+    fullname: str,
+    number: int | None = None,
+    input_id: str | None = None,
+    parameters: dict | None = None,
+    action: Literal['proceed', 'abort'] = 'proceed',
+) -> dict:
+    """Respond to a pipeline input step of a build that is paused for input in Jenkins
+
+    Warnings:
+        Omitting parameters proceeds without submitting any values — Jenkins does not fall back to the
+        declared defaults. Call get_pending_inputs first when the input declares parameters.
+        If this call times out the input may or may not have been settled: re-check with
+        get_pending_inputs rather than retrying, because a settled input rejects a second submission.
+
+    Args:
+        fullname: The fullname of the job
+        number: The number of the build, if None, use the last build
+        input_id: The id of the pending input, if None, resolved automatically when exactly one is pending
+        parameters: A mapping of parameter name to value, e.g. {'APPROVE': True, 'TARGET': 'prod'}
+        action: 'proceed' to continue the pipeline, 'abort' to reject the input and abort the build
+
+    Returns:
+        A dict with the fullname, number, inputId and action that were submitted
+    """
+    if number is None:
+        number = _last_build_number(ctx, fullname)
+
+    if action == 'abort' and parameters:
+        raise ValueError(f'parameters cannot be combined with action="abort" for {fullname} #{number}')
+
+    if input_id is None:
+        pending_inputs = jenkins(ctx).get_build_pending_inputs(fullname=fullname, number=number)
+        if not pending_inputs:
+            raise ValueError(f'No pending input for {fullname} #{number}')
+        if len(pending_inputs) > 1:
+            ids = ', '.join(pending_input.id for pending_input in pending_inputs)
+            raise ValueError(f'Multiple pending inputs for {fullname} #{number}, pass input_id: {ids}')
+        input_id = pending_inputs[0].id
+
+    if action == 'abort':
+        jenkins_action = 'abort'
+    else:
+        jenkins_action = 'proceed' if parameters else 'proceedEmpty'
+
+    jenkins(ctx).submit_build_input(
+        fullname=fullname, number=number, input_id=input_id, action=jenkins_action, parameters=parameters
+    )
+
+    return {'fullname': fullname, 'number': number, 'inputId': input_id, 'action': action}
 
 
 @mcp.tool(tags=['read'])

--- a/tests/test_jenkins/test_rest_client.py
+++ b/tests/test_jenkins/test_rest_client.py
@@ -1,7 +1,7 @@
 import pytest
 from requests import HTTPError
 
-from mcp_jenkins.jenkins import Jenkins
+from mcp_jenkins.jenkins import Jenkins, PendingInputsUnavailableError
 from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay, PendingInput
 from mcp_jenkins.jenkins.model.item import (
     Folder,
@@ -654,8 +654,6 @@ class TestBuild:
                 message='Deploy to prod?',
                 proceedText='Deploy',
                 inputs=[{'name': 'TARGET', 'type': 'StringParameterDefinition'}],
-                proceedUrl='/job/example-job/1/wfapi/inputSubmit?inputId=Deploy',
-                abortUrl='/job/example-job/1/input/Deploy/abort',
             )
         ]
 
@@ -678,7 +676,7 @@ class TestBuild:
         response.raise_for_status.side_effect = HTTPError(response=response)
         mock_session.request.return_value = response
 
-        with pytest.raises(ValueError, match='pipeline-rest-api'):
+        with pytest.raises(PendingInputsUnavailableError, match='pipeline-rest-api'):
             jenkins.get_build_pending_inputs(fullname='example-job', number=1)
 
     def test_get_build_pending_inputs_other_http_error(self, jenkins, mock_session, mocker):
@@ -1115,13 +1113,13 @@ class TestItem:
         )
 
     def test_get_last_build_number(self, jenkins, mock_session, mocker):
-        mock_session.request.return_value = mocker.Mock(json=lambda: {'lastBuild': {'number': 42}})
+        mock_session.request.return_value = mocker.Mock(json=lambda: {'buildable': True, 'lastBuild': {'number': 42}})
 
         assert jenkins.get_last_build_number(fullname='example-job') == 42
 
         mock_session.request.assert_called_once_with(
             method='GET',
-            url='https://example.com/job/example-job/api/json?tree=lastBuild[number]',
+            url='https://example.com/job/example-job/api/json?tree=lastBuild[number],buildable',
             headers={'Jenkins-Crumb': 'crumb-value'},
             params=None,
             data=None,
@@ -1129,14 +1127,20 @@ class TestItem:
         )
 
     def test_get_last_build_number_never_built(self, jenkins, mock_session, mocker):
-        mock_session.request.return_value = mocker.Mock(json=lambda: {'lastBuild': None})
+        mock_session.request.return_value = mocker.Mock(json=lambda: {'buildable': True, 'lastBuild': None})
+
+        assert jenkins.get_last_build_number(fullname='example-job') is None
+
+    def test_get_last_build_number_never_built_without_last_build_key(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(json=lambda: {'buildable': True})
 
         assert jenkins.get_last_build_number(fullname='example-job') is None
 
     def test_get_last_build_number_item_without_builds(self, jenkins, mock_session, mocker):
         mock_session.request.return_value = mocker.Mock(json=lambda: {})
 
-        assert jenkins.get_last_build_number(fullname='example-folder') is None
+        with pytest.raises(ValueError, match='cannot have builds'):
+            jenkins.get_last_build_number(fullname='example-folder')
 
     def test_get_item_config(self, jenkins, mock_session, mocker):
         mock_session.request.return_value = mocker.Mock(text='<project>config</project>')

--- a/tests/test_jenkins/test_rest_client.py
+++ b/tests/test_jenkins/test_rest_client.py
@@ -2,7 +2,7 @@ import pytest
 from requests import HTTPError
 
 from mcp_jenkins.jenkins import Jenkins
-from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay
+from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay, PendingInput
 from mcp_jenkins.jenkins.model.item import (
     Folder,
     FreeStyleProject,
@@ -631,6 +631,133 @@ class TestBuild:
             params=None,
             data=None,
             timeout=75,
+        )
+
+    def test_get_build_pending_inputs(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(
+            json=lambda: [
+                {
+                    'id': 'Deploy',
+                    'message': 'Deploy to prod?',
+                    'proceedText': 'Deploy',
+                    'inputs': [{'name': 'TARGET', 'type': 'StringParameterDefinition'}],
+                    'proceedUrl': '/job/example-job/1/wfapi/inputSubmit?inputId=Deploy',
+                    'abortUrl': '/job/example-job/1/input/Deploy/abort',
+                    '_links': {'self': {'href': '/whatever'}},
+                }
+            ]
+        )
+
+        assert jenkins.get_build_pending_inputs(fullname='example-job', number=1) == [
+            PendingInput(
+                id='Deploy',
+                message='Deploy to prod?',
+                proceedText='Deploy',
+                inputs=[{'name': 'TARGET', 'type': 'StringParameterDefinition'}],
+                proceedUrl='/job/example-job/1/wfapi/inputSubmit?inputId=Deploy',
+                abortUrl='/job/example-job/1/input/Deploy/abort',
+            )
+        ]
+
+        mock_session.request.assert_called_once_with(
+            method='GET',
+            url='https://example.com/job/example-job/1/wfapi/pendingInputActions',
+            headers={'Jenkins-Crumb': 'crumb-value'},
+            params=None,
+            data=None,
+            timeout=75,
+        )
+
+    def test_get_build_pending_inputs_empty(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(json=lambda: [])
+
+        assert jenkins.get_build_pending_inputs(fullname='example-job', number=1) == []
+
+    def test_get_build_pending_inputs_missing_endpoint(self, jenkins, mock_session, mocker):
+        response = mocker.Mock(status_code=404)
+        response.raise_for_status.side_effect = HTTPError(response=response)
+        mock_session.request.return_value = response
+
+        with pytest.raises(ValueError, match='pipeline-rest-api'):
+            jenkins.get_build_pending_inputs(fullname='example-job', number=1)
+
+    def test_get_build_pending_inputs_other_http_error(self, jenkins, mock_session, mocker):
+        response = mocker.Mock(status_code=500)
+        response.raise_for_status.side_effect = HTTPError(response=response)
+        mock_session.request.return_value = response
+
+        with pytest.raises(HTTPError):
+            jenkins.get_build_pending_inputs(fullname='example-job', number=1)
+
+    def test_submit_build_input_proceed_with_parameters(self, jenkins, mock_session):
+        assert (
+            jenkins.submit_build_input(
+                fullname='example-job',
+                number=7,
+                input_id='Deploy',
+                action='proceed',
+                parameters={'APPROVE': True, 'TARGET': 'prod', 'COUNT': 3},
+            )
+            is None
+        )
+
+        mock_session.request.assert_called_once_with(
+            method='POST',
+            url='https://example.com/job/example-job/7/input/Deploy/proceed',
+            headers={'Jenkins-Crumb': 'crumb-value'},
+            params=None,
+            data={
+                'json': (
+                    '{"parameter": [{"name": "APPROVE", "value": true}, '
+                    '{"name": "TARGET", "value": "prod"}, {"name": "COUNT", "value": 3}]}'
+                )
+            },
+            timeout=75,
+        )
+
+    def test_submit_build_input_proceed_without_parameters_still_sends_json(self, jenkins, mock_session):
+        jenkins.submit_build_input(fullname='example-job', number=7, input_id='Deploy', action='proceed')
+
+        assert mock_session.request.call_args.kwargs['data'] == {'json': '{"parameter": []}'}
+
+    def test_submit_build_input_proceed_empty(self, jenkins, mock_session):
+        jenkins.submit_build_input(fullname='example-job', number=7, input_id='Deploy', action='proceedEmpty')
+
+        mock_session.request.assert_called_once_with(
+            method='POST',
+            url='https://example.com/job/example-job/7/input/Deploy/proceedEmpty',
+            headers={'Jenkins-Crumb': 'crumb-value'},
+            params=None,
+            data=None,
+            timeout=75,
+        )
+
+    def test_submit_build_input_abort(self, jenkins, mock_session):
+        jenkins.submit_build_input(fullname='example-job', number=7, input_id='Deploy', action='abort')
+
+        mock_session.request.assert_called_once_with(
+            method='POST',
+            url='https://example.com/job/example-job/7/input/Deploy/abort',
+            headers={'Jenkins-Crumb': 'crumb-value'},
+            params=None,
+            data=None,
+            timeout=75,
+        )
+
+    def test_submit_build_input_quotes_input_id(self, jenkins, mock_session):
+        jenkins.submit_build_input(fullname='example-job', number=7, input_id='Deploy to prod/now', action='abort')
+
+        assert (
+            mock_session.request.call_args.kwargs['url']
+            == 'https://example.com/job/example-job/7/input/Deploy%20to%20prod%2Fnow/abort'
+        )
+
+    def test_submit_build_input_in_folder(self, jenkins, mock_session):
+        jenkins.submit_build_input(fullname='folder/sub/example-job', number=7, input_id='Deploy', action='abort')
+
+        assert (
+            mock_session.request.call_args.kwargs['url']
+            == 'https://example.com/job/folder/job/sub/job/example-job/7/input/Deploy/abort'
         )
 
     def test_get_build_replay(self, jenkins, mock_session, mocker):

--- a/tests/test_jenkins/test_rest_client.py
+++ b/tests/test_jenkins/test_rest_client.py
@@ -689,6 +689,12 @@ class TestBuild:
         with pytest.raises(HTTPError):
             jenkins.get_build_pending_inputs(fullname='example-job', number=1)
 
+    def test_get_build_pending_inputs_http_error_without_response(self, jenkins, mock_session):
+        mock_session.request.side_effect = HTTPError('Connection aborted')
+
+        with pytest.raises(HTTPError, match='Connection aborted'):
+            jenkins.get_build_pending_inputs(fullname='example-job', number=1)
+
     def test_submit_build_input_proceed_with_parameters(self, jenkins, mock_session):
         assert (
             jenkins.submit_build_input(
@@ -1107,6 +1113,30 @@ class TestItem:
                 )
             ],
         )
+
+    def test_get_last_build_number(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(json=lambda: {'lastBuild': {'number': 42}})
+
+        assert jenkins.get_last_build_number(fullname='example-job') == 42
+
+        mock_session.request.assert_called_once_with(
+            method='GET',
+            url='https://example.com/job/example-job/api/json?tree=lastBuild[number]',
+            headers={'Jenkins-Crumb': 'crumb-value'},
+            params=None,
+            data=None,
+            timeout=75,
+        )
+
+    def test_get_last_build_number_never_built(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(json=lambda: {'lastBuild': None})
+
+        assert jenkins.get_last_build_number(fullname='example-job') is None
+
+    def test_get_last_build_number_item_without_builds(self, jenkins, mock_session, mocker):
+        mock_session.request.return_value = mocker.Mock(json=lambda: {})
+
+        assert jenkins.get_last_build_number(fullname='example-folder') is None
 
     def test_get_item_config(self, jenkins, mock_session, mocker):
         mock_session.request.return_value = mocker.Mock(text='<project>config</project>')

--- a/tests/test_server/test_build.py
+++ b/tests/test_server/test_build.py
@@ -1,6 +1,7 @@
 import pytest
 
-from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay
+from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay, PendingInput
+from mcp_jenkins.jenkins.model.item import Folder, Job
 from mcp_jenkins.server import build
 
 
@@ -115,6 +116,161 @@ async def test_get_build_parameters(mock_jenkins, mocker):
 async def test_stop_build(mock_jenkins, mocker):
     await build.stop_build(mocker.Mock(), fullname='job1', number=1)
     mock_jenkins.stop_build.assert_called_once_with(fullname='job1', number=1)
+
+
+@pytest.mark.asyncio
+async def test_get_pending_inputs(mock_jenkins, mocker):
+    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(
+            id='Deploy',
+            message='Deploy to prod?',
+            proceedText='Deploy',
+            inputs=[{'name': 'TARGET', 'type': 'StringParameterDefinition'}],
+        )
+    ]
+
+    assert await build.get_pending_inputs(mocker.Mock(), fullname='job1') == [
+        {
+            'id': 'Deploy',
+            'message': 'Deploy to prod?',
+            'proceedText': 'Deploy',
+            'inputs': [{'name': 'TARGET', 'type': 'StringParameterDefinition'}],
+        }
+    ]
+    mock_jenkins.get_build_pending_inputs.assert_called_once_with(fullname='job1', number=1)
+
+
+@pytest.mark.asyncio
+async def test_get_pending_inputs_with_number(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
+
+    assert await build.get_pending_inputs(mocker.Mock(), fullname='job1', number=5) == [{'id': 'Deploy', 'inputs': []}]
+    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_build_pending_inputs.assert_called_once_with(fullname='job1', number=5)
+
+
+@pytest.mark.asyncio
+async def test_get_pending_inputs_empty(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = []
+
+    assert await build.get_pending_inputs(mocker.Mock(), fullname='job1', number=5) == []
+
+
+@pytest.mark.asyncio
+async def test_get_pending_inputs_no_build(mock_jenkins, mocker):
+    mock_jenkins.get_item.return_value = Job(_class='hudson.model.Job', name='job1', url='url', color='notbuilt')
+
+    with pytest.raises(ValueError, match='No build found for job: job1'):
+        await build.get_pending_inputs(mocker.Mock(), fullname='job1')
+
+
+@pytest.mark.asyncio
+async def test_submit_input_auto_resolves_number_and_input_id(mock_jenkins, mocker):
+    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
+
+    assert await build.submit_input(mocker.Mock(), fullname='job1') == {
+        'fullname': 'job1',
+        'number': 1,
+        'inputId': 'Deploy',
+        'action': 'proceed',
+    }
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1', number=1, input_id='Deploy', action='proceedEmpty', parameters=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_with_parameters(mock_jenkins, mocker):
+    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
+
+    await build.submit_input(mocker.Mock(), fullname='job1', parameters={'APPROVE': True, 'TARGET': 'prod'})
+
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1',
+        number=1,
+        input_id='Deploy',
+        action='proceed',
+        parameters={'APPROVE': True, 'TARGET': 'prod'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_with_explicit_input_id(mock_jenkins, mocker):
+    await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy')
+
+    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_build_pending_inputs.assert_not_called()
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1', number=7, input_id='Deploy', action='proceedEmpty', parameters=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_abort(mock_jenkins, mocker):
+    assert await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy', action='abort') == {
+        'fullname': 'job1',
+        'number': 7,
+        'inputId': 'Deploy',
+        'action': 'abort',
+    }
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1', number=7, input_id='Deploy', action='abort', parameters=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_abort_with_parameters(mock_jenkins, mocker):
+    with pytest.raises(ValueError, match='cannot be combined'):
+        await build.submit_input(
+            mocker.Mock(), fullname='job1', number=7, input_id='Deploy', action='abort', parameters={'A': 'b'}
+        )
+
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_no_pending_inputs(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = []
+
+    with pytest.raises(ValueError, match='No pending input for job1 #1'):
+        await build.submit_input(mocker.Mock(), fullname='job1', number=1)
+
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_multiple_pending_inputs(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy'), PendingInput(id='Rollback')]
+
+    with pytest.raises(ValueError, match='Multiple pending inputs') as exc_info:
+        await build.submit_input(mocker.Mock(), fullname='job1', number=1)
+
+    assert 'Deploy' in str(exc_info.value)
+    assert 'Rollback' in str(exc_info.value)
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_no_build(mock_jenkins, mocker):
+    mock_jenkins.get_item.return_value = Job(_class='hudson.model.Job', name='job1', url='url', color='notbuilt')
+
+    with pytest.raises(ValueError, match='No build found for job: job1'):
+        await build.submit_input(mocker.Mock(), fullname='job1')
+
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_on_item_without_last_build(mock_jenkins, mocker):
+    mock_jenkins.get_item.return_value = Folder(_class='com.cloudbees...Folder', name='folder1', url='url', jobs=[])
+
+    with pytest.raises(ValueError, match='No build found for job: folder1'):
+        await build.submit_input(mocker.Mock(), fullname='folder1')
+
+    mock_jenkins.submit_build_input.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_server/test_build.py
+++ b/tests/test_server/test_build.py
@@ -1,7 +1,6 @@
 import pytest
 
 from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay, PendingInput
-from mcp_jenkins.jenkins.model.item import Folder, Job
 from mcp_jenkins.server import build
 
 
@@ -120,7 +119,7 @@ async def test_stop_build(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_pending_inputs(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_pending_inputs.return_value = [
         PendingInput(
             id='Deploy',
@@ -146,7 +145,7 @@ async def test_get_pending_inputs_with_number(mock_jenkins, mocker):
     mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
 
     assert await build.get_pending_inputs(mocker.Mock(), fullname='job1', number=5) == [{'id': 'Deploy', 'inputs': []}]
-    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_last_build_number.assert_not_called()
     mock_jenkins.get_build_pending_inputs.assert_called_once_with(fullname='job1', number=5)
 
 
@@ -159,23 +158,25 @@ async def test_get_pending_inputs_empty(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_pending_inputs_no_build(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value = Job(_class='hudson.model.Job', name='job1', url='url', color='notbuilt')
+    mock_jenkins.get_last_build_number.return_value = None
 
     with pytest.raises(ValueError, match='No build found for job: job1'):
         await build.get_pending_inputs(mocker.Mock(), fullname='job1')
 
+    mock_jenkins.get_build_pending_inputs.assert_not_called()
+
 
 @pytest.mark.asyncio
-async def test_submit_input_auto_resolves_number_and_input_id(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+async def test_submit_input_auto_resolves_input_id(mock_jenkins, mocker):
     mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
 
-    assert await build.submit_input(mocker.Mock(), fullname='job1') == {
+    assert await build.submit_input(mocker.Mock(), fullname='job1', number=1) == {
         'fullname': 'job1',
         'number': 1,
         'inputId': 'Deploy',
-        'action': 'proceed',
+        'action': 'proceedEmpty',
     }
+    mock_jenkins.get_item.assert_not_called()
     mock_jenkins.submit_build_input.assert_called_once_with(
         fullname='job1', number=1, input_id='Deploy', action='proceedEmpty', parameters=None
     )
@@ -183,10 +184,9 @@ async def test_submit_input_auto_resolves_number_and_input_id(mock_jenkins, mock
 
 @pytest.mark.asyncio
 async def test_submit_input_with_parameters(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
     mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
 
-    await build.submit_input(mocker.Mock(), fullname='job1', parameters={'APPROVE': True, 'TARGET': 'prod'})
+    await build.submit_input(mocker.Mock(), fullname='job1', number=1, parameters={'APPROVE': True, 'TARGET': 'prod'})
 
     mock_jenkins.submit_build_input.assert_called_once_with(
         fullname='job1',
@@ -194,6 +194,68 @@ async def test_submit_input_with_parameters(mock_jenkins, mocker):
         input_id='Deploy',
         action='proceed',
         parameters={'APPROVE': True, 'TARGET': 'prod'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_rejects_undeclared_parameter(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(id='Deploy', inputs=[{'name': 'APPROVED', 'type': 'BooleanParameterDefinition'}])
+    ]
+
+    with pytest.raises(ValueError, match='does not declare APPROVE') as exc_info:
+        await build.submit_input(mocker.Mock(), fullname='job1', number=1, parameters={'APPROVE': True})
+
+    assert 'Declared parameters: APPROVED' in str(exc_info.value)
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_refuses_to_proceed_empty_on_declared_parameters(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(id='Deploy', inputs=[{'name': 'ENV', 'type': 'ChoiceParameterDefinition'}])
+    ]
+
+    with pytest.raises(ValueError, match='declares ENV'):
+        await build.submit_input(mocker.Mock(), fullname='job1', number=1)
+
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_aborts_declared_parameter_input_without_values(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(id='Deploy', inputs=[{'name': 'ENV', 'type': 'ChoiceParameterDefinition'}])
+    ]
+
+    await build.submit_input(mocker.Mock(), fullname='job1', number=1, action='abort')
+
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1', number=1, input_id='Deploy', action='abort', parameters=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_accepts_declared_parameters(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(id='Deploy', inputs=[{'name': 'APPROVED', 'type': 'BooleanParameterDefinition'}])
+    ]
+
+    result = await build.submit_input(mocker.Mock(), fullname='job1', number=1, parameters={'APPROVED': True})
+
+    assert result['action'] == 'proceed'
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1', number=1, input_id='Deploy', action='proceed', parameters={'APPROVED': True}
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_does_not_validate_names_with_explicit_input_id(mock_jenkins, mocker):
+    await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy', parameters={'ANYTHING': True})
+
+    mock_jenkins.get_build_pending_inputs.assert_not_called()
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1', number=7, input_id='Deploy', action='proceed', parameters={'ANYTHING': True}
     )
 
 
@@ -250,26 +312,6 @@ async def test_submit_input_multiple_pending_inputs(mock_jenkins, mocker):
 
     assert 'Deploy' in str(exc_info.value)
     assert 'Rollback' in str(exc_info.value)
-    mock_jenkins.submit_build_input.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_submit_input_no_build(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value = Job(_class='hudson.model.Job', name='job1', url='url', color='notbuilt')
-
-    with pytest.raises(ValueError, match='No build found for job: job1'):
-        await build.submit_input(mocker.Mock(), fullname='job1')
-
-    mock_jenkins.submit_build_input.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_submit_input_on_item_without_last_build(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value = Folder(_class='com.cloudbees...Folder', name='folder1', url='url', jobs=[])
-
-    with pytest.raises(ValueError, match='No build found for job: folder1'):
-        await build.submit_input(mocker.Mock(), fullname='folder1')
-
     mock_jenkins.submit_build_input.assert_not_called()
 
 

--- a/tests/test_server/test_build.py
+++ b/tests/test_server/test_build.py
@@ -1,5 +1,7 @@
 import pytest
+from requests.exceptions import HTTPError
 
+from mcp_jenkins.jenkins import PendingInputsUnavailableError
 from mcp_jenkins.jenkins.model.build import Artifact, Build, BuildReplay, PendingInput
 from mcp_jenkins.server import build
 
@@ -126,8 +128,6 @@ async def test_get_pending_inputs(mock_jenkins, mocker):
             message='Deploy to prod?',
             proceedText='Deploy',
             inputs=[{'name': 'TARGET', 'type': 'StringParameterDefinition'}],
-            proceedUrl='/job/job1/1/wfapi/inputSubmit?inputId=Deploy',
-            abortUrl='/job/job1/1/input/Deploy/abort',
         )
     ]
 
@@ -327,13 +327,62 @@ async def test_submit_input_explicit_input_id_not_pending(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_submit_input_explicit_input_id_without_wfapi_submits_unvalidated(mock_jenkins, mocker):
-    mock_jenkins.get_build_pending_inputs.side_effect = ValueError('No wfapi pending input endpoint for job1 #7')
+    mock_jenkins.get_build_pending_inputs.side_effect = PendingInputsUnavailableError(
+        'No wfapi pending input endpoint for job1 #7'
+    )
 
     await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy', parameters={'ANYTHING': True})
 
     mock_jenkins.submit_build_input.assert_called_once_with(
         fullname='job1', number=7, input_id='Deploy', action='proceed', parameters={'ANYTHING': True}
     )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_explicit_input_id_wfapi_http_error_submits_unvalidated(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.side_effect = HTTPError('500 Server Error')
+
+    await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy', parameters={'ANYTHING': True})
+
+    mock_jenkins.submit_build_input.assert_called_once_with(
+        fullname='job1', number=7, input_id='Deploy', action='proceed', parameters={'ANYTHING': True}
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_input_malformed_wfapi_response_does_not_skip_validation(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.side_effect = ValueError('Expecting value: line 1 column 1 (char 0)')
+
+    with pytest.raises(ValueError, match='Expecting value'):
+        await build.submit_input(
+            mocker.Mock(), fullname='job1', number=7, input_id='Deploy', parameters={'ANYTHING': True}
+        )
+
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_failed_submit_reports_discovery_error(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.side_effect = PendingInputsUnavailableError(
+        'No wfapi pending input endpoint for job1 #999'
+    )
+    mock_jenkins.submit_build_input.side_effect = HTTPError('404 Client Error')
+
+    with pytest.raises(ValueError, match='No wfapi pending input endpoint') as exc_info:
+        await build.submit_input(mocker.Mock(), fullname='job1', number=999, input_id='Deploy')
+
+    assert '404 Client Error' in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_submit_input_failed_submit_hints_at_settled_input(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
+    mock_jenkins.submit_build_input.side_effect = HTTPError('400 Client Error')
+
+    with pytest.raises(ValueError, match='may already be settled') as exc_info:
+        await build.submit_input(mocker.Mock(), fullname='job1', number=1)
+
+    assert '400 Client Error' in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_server/test_build.py
+++ b/tests/test_server/test_build.py
@@ -27,7 +27,7 @@ async def test_get_running_builds(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_build(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build.return_value = Build(number=1, url='1', building=False, timestamp=1234567890)
 
     assert await build.get_build(mocker.Mock(), fullname='job1') == {
@@ -40,7 +40,7 @@ async def test_get_build(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_build_scripts(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_replay.return_value = BuildReplay(scripts=['script1', 'script2'])
 
     assert await build.get_build_scripts(mocker.Mock(), fullname='job1') == [
@@ -51,7 +51,7 @@ async def test_get_build_scripts(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_build_console_output(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_console_output.return_value = 'Console output here'
 
     assert await build.get_build_console_output(mocker.Mock(), fullname='job1') == 'Console output here'
@@ -65,7 +65,7 @@ async def test_get_build_console_output_with_number(mock_jenkins, mocker):
     mock_jenkins.get_build_console_output.return_value = 'output'
 
     assert await build.get_build_console_output(mocker.Mock(), fullname='job1', number=5) == 'output'
-    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_last_build_number.assert_not_called()
     mock_jenkins.get_build_console_output.assert_called_once_with(
         fullname='job1', number=5, pattern=None, offset=0, limit=None
     )
@@ -86,7 +86,7 @@ async def test_get_build_console_output_with_all_params(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_build_console_output_no_build(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = None
+    mock_jenkins.get_last_build_number.return_value = None
 
     with pytest.raises(ValueError, match='No build found for job: job1'):
         await build.get_build_console_output(mocker.Mock(), fullname='job1')
@@ -94,7 +94,7 @@ async def test_get_build_console_output_no_build(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_build_test_reports(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_test_report.return_value = {'reports': ['report1', 'report2']}
 
     assert await build.get_build_test_report(mocker.Mock(), fullname='job1') == {'reports': ['report1', 'report2']}
@@ -102,7 +102,7 @@ async def test_get_build_test_reports(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_build_parameters(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_parameters.return_value = {'BRANCH': 'main', 'DEBUG': True}
 
     assert await build.get_build_parameters(mocker.Mock(), fullname='job1') == {
@@ -126,6 +126,8 @@ async def test_get_pending_inputs(mock_jenkins, mocker):
             message='Deploy to prod?',
             proceedText='Deploy',
             inputs=[{'name': 'TARGET', 'type': 'StringParameterDefinition'}],
+            proceedUrl='/job/job1/1/wfapi/inputSubmit?inputId=Deploy',
+            abortUrl='/job/job1/1/input/Deploy/abort',
         )
     ]
 
@@ -176,7 +178,7 @@ async def test_submit_input_auto_resolves_input_id(mock_jenkins, mocker):
         'inputId': 'Deploy',
         'action': 'proceedEmpty',
     }
-    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_last_build_number.assert_not_called()
     mock_jenkins.submit_build_input.assert_called_once_with(
         fullname='job1', number=1, input_id='Deploy', action='proceedEmpty', parameters=None
     )
@@ -184,7 +186,15 @@ async def test_submit_input_auto_resolves_input_id(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_submit_input_with_parameters(mock_jenkins, mocker):
-    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(
+            id='Deploy',
+            inputs=[
+                {'name': 'APPROVE', 'type': 'BooleanParameterDefinition'},
+                {'name': 'TARGET', 'type': 'StringParameterDefinition'},
+            ],
+        )
+    ]
 
     await build.submit_input(mocker.Mock(), fullname='job1', number=1, parameters={'APPROVE': True, 'TARGET': 'prod'})
 
@@ -207,6 +217,35 @@ async def test_submit_input_rejects_undeclared_parameter(mock_jenkins, mocker):
         await build.submit_input(mocker.Mock(), fullname='job1', number=1, parameters={'APPROVE': True})
 
     assert 'Declared parameters: APPROVED' in str(exc_info.value)
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_rejects_parameters_on_parameterless_input(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
+
+    with pytest.raises(ValueError, match='does not declare APPROVE') as exc_info:
+        await build.submit_input(mocker.Mock(), fullname='job1', number=1, parameters={'APPROVE': True})
+
+    assert 'Declared parameters: none' in str(exc_info.value)
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_rejects_partial_parameters(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(
+            id='Deploy',
+            inputs=[
+                {'name': 'CONFIRM', 'type': 'BooleanParameterDefinition'},
+                {'name': 'TARGET', 'type': 'StringParameterDefinition'},
+            ],
+        )
+    ]
+
+    with pytest.raises(ValueError, match='no value for CONFIRM'):
+        await build.submit_input(mocker.Mock(), fullname='job1', number=1, parameters={'TARGET': 'prod'})
+
     mock_jenkins.submit_build_input.assert_not_called()
 
 
@@ -250,10 +289,48 @@ async def test_submit_input_accepts_declared_parameters(mock_jenkins, mocker):
 
 
 @pytest.mark.asyncio
-async def test_submit_input_does_not_validate_names_with_explicit_input_id(mock_jenkins, mocker):
+async def test_submit_input_validates_names_with_explicit_input_id(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(id='Deploy', inputs=[{'name': 'TARGET', 'type': 'StringParameterDefinition'}])
+    ]
+
+    with pytest.raises(ValueError, match='does not declare ANYTHING'):
+        await build.submit_input(
+            mocker.Mock(), fullname='job1', number=7, input_id='Deploy', parameters={'ANYTHING': True}
+        )
+
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_explicit_input_id_refuses_to_proceed_empty_on_declared_parameters(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [
+        PendingInput(id='Deploy', inputs=[{'name': 'TARGET', 'type': 'StringParameterDefinition'}])
+    ]
+
+    with pytest.raises(ValueError, match='no value for TARGET'):
+        await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy')
+
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_explicit_input_id_not_pending(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Rollback')]
+
+    with pytest.raises(ValueError, match='No pending input Deploy') as exc_info:
+        await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy')
+
+    assert 'Rollback' in str(exc_info.value)
+    mock_jenkins.submit_build_input.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_input_explicit_input_id_without_wfapi_submits_unvalidated(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.side_effect = ValueError('No wfapi pending input endpoint for job1 #7')
+
     await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy', parameters={'ANYTHING': True})
 
-    mock_jenkins.get_build_pending_inputs.assert_not_called()
     mock_jenkins.submit_build_input.assert_called_once_with(
         fullname='job1', number=7, input_id='Deploy', action='proceed', parameters={'ANYTHING': True}
     )
@@ -261,10 +338,12 @@ async def test_submit_input_does_not_validate_names_with_explicit_input_id(mock_
 
 @pytest.mark.asyncio
 async def test_submit_input_with_explicit_input_id(mock_jenkins, mocker):
+    mock_jenkins.get_build_pending_inputs.return_value = [PendingInput(id='Deploy')]
+
     await build.submit_input(mocker.Mock(), fullname='job1', number=7, input_id='Deploy')
 
-    mock_jenkins.get_item.assert_not_called()
-    mock_jenkins.get_build_pending_inputs.assert_not_called()
+    mock_jenkins.get_last_build_number.assert_not_called()
+    mock_jenkins.get_build_pending_inputs.assert_called_once_with(fullname='job1', number=7)
     mock_jenkins.submit_build_input.assert_called_once_with(
         fullname='job1', number=7, input_id='Deploy', action='proceedEmpty', parameters=None
     )
@@ -278,6 +357,7 @@ async def test_submit_input_abort(mock_jenkins, mocker):
         'inputId': 'Deploy',
         'action': 'abort',
     }
+    mock_jenkins.get_build_pending_inputs.assert_not_called()
     mock_jenkins.submit_build_input.assert_called_once_with(
         fullname='job1', number=7, input_id='Deploy', action='abort', parameters=None
     )
@@ -317,7 +397,7 @@ async def test_submit_input_multiple_pending_inputs(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_all_build_artifacts(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_artifacts.return_value = [
         Artifact(
             fileName='index.html',
@@ -342,13 +422,13 @@ async def test_get_all_build_artifacts_with_number(mock_jenkins, mocker):
     mock_jenkins.get_build_artifacts.return_value = []
 
     assert await build.get_all_build_artifacts(mocker.Mock(), fullname='job1', number=5) == []
-    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_last_build_number.assert_not_called()
     mock_jenkins.get_build_artifacts.assert_called_once_with(fullname='job1', number=5)
 
 
 @pytest.mark.asyncio
 async def test_get_build_artifact_text(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_artifact.return_value = b'<html>report</html>'
 
     result = await build.get_build_artifact(
@@ -359,7 +439,7 @@ async def test_get_build_artifact_text(mock_jenkins, mocker):
 
 @pytest.mark.asyncio
 async def test_get_build_artifact_binary(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_artifact.return_value = bytes(range(256))
 
     result = await build.get_build_artifact(mocker.Mock(), fullname='job1', relative_path='trace.zip')
@@ -374,14 +454,14 @@ async def test_get_build_artifact_with_number(mock_jenkins, mocker):
     mock_jenkins.get_build_artifact.return_value = b'data'
 
     result = await build.get_build_artifact(mocker.Mock(), fullname='job1', relative_path='file.txt', number=3)
-    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_last_build_number.assert_not_called()
     mock_jenkins.get_build_artifact.assert_called_once_with(fullname='job1', number=3, relative_path='file.txt')
     assert result == {'content': 'data', 'encoding': 'utf-8'}
 
 
 @pytest.mark.asyncio
 async def test_get_build_artifact_url(mock_jenkins, mocker):
-    mock_jenkins.get_item.return_value.lastBuild.number = 1
+    mock_jenkins.get_last_build_number.return_value = 1
     mock_jenkins.get_build_artifact_url.return_value = 'https://jenkins.example.com/job/job1/1/artifact/trace.zip'
 
     result = await build.get_build_artifact_url(mocker.Mock(), fullname='job1', relative_path='trace.zip')
@@ -393,6 +473,6 @@ async def test_get_build_artifact_url_with_number(mock_jenkins, mocker):
     mock_jenkins.get_build_artifact_url.return_value = 'https://jenkins.example.com/job/job1/5/artifact/report.html'
 
     result = await build.get_build_artifact_url(mocker.Mock(), fullname='job1', relative_path='report.html', number=5)
-    mock_jenkins.get_item.assert_not_called()
+    mock_jenkins.get_last_build_number.assert_not_called()
     mock_jenkins.get_build_artifact_url.assert_called_once_with(fullname='job1', number=5, relative_path='report.html')
     assert result == 'https://jenkins.example.com/job/job1/5/artifact/report.html'

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "mcp-jenkins"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Adds two tools for Jenkins pipeline `input` steps, so an agent can see what a build showing **"Paused for Input"** is waiting on and respond to it.

| Tool | Tag | Purpose |
|---|---|---|
| `get_pending_inputs` | read | List a build's pending inputs — id, message, proceedText, and the declared parameter definitions |
| `submit_input` | write | Proceed with or abort a pending input |

## Plugin dependency

`get_pending_inputs` reads the `wfapi/pendingInputActions` endpoint served by `pipeline-rest-api` (bundled with `pipeline-stage-view`). `submit_input` posts to `input/<id>/<action>`, which only needs `pipeline-input-step`, so passing `input_id` explicitly keeps it working on controllers without the stage-view plugin. A missing endpoint raises a dedicated `PendingInputsUnavailableError` rather than a bare `HTTPError`, and `submit_input` degrades to an unvalidated submission only for that specific failure — a malformed response still raises, since silently skipping validation is how a wrong parameter settles the real one with null.

## Safety of the write path

Jenkins does **not** fall back to an input's declared defaults: any parameter you omit is settled as `null`, and `proceedEmpty` settles all of them that way. Left unguarded that turns a dropped argument into a real deploy running with `null` values, so `submit_input`:

- requires an explicit `number`, like `stop_build` — defaulting to `lastBuild` would let an approval land on a newer run while the build the user meant stays paused
- rejects parameter names the input does not declare, and rejects partial submissions where a declared parameter has no value
- reports the Jenkins action actually sent (`proceed` / `proceedEmpty` / `abort`) rather than echoing the requested one
- wraps a failed POST with a "may already be settled, re-check rather than retry" hint, since a settled input rejects a second submission

The `proceedUrl` / `abortUrl` fields are deliberately not modeled: they embed the input id already URL-encoded, and exposing them invites feeding that segment back as `input_id`, which gets encoded a second time on submission.

## Incidental fix to existing tools

Every build tool resolved an omitted `number` with `get_item(depth=1).lastBuild.number`. That raises `AttributeError` on a job that has never been built (`lastBuild` is `None`) and on a folder (no such field), and it pulls the job's entire build list to read one integer. All ten call sites now share `_resolve_build_number`, backed by a new `Jenkins.get_last_build_number` using `tree=lastBuild[number],buildable`.

The `buildable` field distinguishes a never-built job from an item that cannot have builds at all. I verified this against a live Jenkins 2.440.3 controller with 8028 items: `WorkflowJob` (7773) and `FreeStyleProject` (19) always expose the key, `WorkflowMultiBranchProject` (144) and `Folder` (92) never do, with no inconsistency inside any class. Disabled jobs return `buildable: false` with the key present, so the check tests for presence rather than truthiness. Unknown tree fields are silently omitted by Jenkins rather than returning 400.

## Testing

`uv run pytest` — 170 passing, including the never-built, folder, missing-plugin, malformed-response, wrong-input-id, partial-parameter and failed-submit paths. `ruff` and `ruff-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)